### PR TITLE
Alternative setup for bank account creation

### DIFF
--- a/pkg/moov/bank_account.go
+++ b/pkg/moov/bank_account.go
@@ -97,7 +97,17 @@ func WithBankAccount(bankAccount BankAccount) CreateBankAccountType {
 
 func WithPlaidLink(plaidLink PlaidLink) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		bankAccountJSON, err := json.Marshal(plaidLink)
+		// need to use a map to add the top level "plaidLink" json key. expected format is:
+		//	{
+		// 		"plaidLink": {
+		// 			"publicToken": "insert token"
+		// 		}
+		// 	}
+
+		plaidLinkMap := map[string]PlaidLink{
+			"plaidLink": plaidLink,
+		}
+		bankAccountJSON, err := json.Marshal(plaidLinkMap)
 		if err != nil {
 			return err
 		}
@@ -108,7 +118,17 @@ func WithPlaidLink(plaidLink PlaidLink) CreateBankAccountType {
 
 func WithPlaid(plaid Plaid) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		bankAccountJSON, err := json.Marshal(plaid)
+		// need to use a map to add the top level "plaid" json key. expected format is:
+		//	{
+		// 		"plaid": {
+		// 			"token": "insert token"
+		// 		}
+		// 	}
+
+		plaidMap := map[string]Plaid{
+			"plaid": plaid,
+		}
+		bankAccountJSON, err := json.Marshal(plaidMap)
 		if err != nil {
 			return err
 		}
@@ -119,7 +139,17 @@ func WithPlaid(plaid Plaid) CreateBankAccountType {
 
 func WithMX(mx MX) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		bankAccountJSON, err := json.Marshal(mx)
+		// need to use a map to add the top level "mx" json key. expected format is:
+		//	{
+		// 		"mx": {
+		// 			"authorizationCode": "testing"
+		// 		}
+		// 	}
+
+		mxMap := map[string]MX{
+			"mx": mx,
+		}
+		bankAccountJSON, err := json.Marshal(mxMap)
 		if err != nil {
 			return err
 		}
@@ -212,74 +242,5 @@ func (c Client) MicroDepositConfirm(ctx context.Context, accountID string, bankA
 		return ErrAmountIncorrect
 	default:
 		return resp.Error()
-	}
-}
-
-// CreatePlaidLink creates a new bank account for the given customer account using Plaid processor_token
-func (c Client) CreateBankAccountWithPlaid(ctx context.Context, accountID string, plaid Plaid) (*BankAccount, error) {
-	payload := BankAccountPayload{
-		Plaid: &plaid,
-	}
-	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodPost, pathBankAccounts, accountID),
-		AcceptJson(),
-		JsonBody(payload))
-	if err != nil {
-		return nil, err
-	}
-
-	switch resp.Status() {
-	case StatusCompleted:
-		return CompletedObjectOrError[BankAccount](resp)
-	case StatusStateConflict:
-		return nil, ErrDuplicateBankAccount
-	default:
-		return nil, resp.Error()
-	}
-}
-
-// CreateBankAccountWithPlaidLink creates a new bank account for the given customer account using Plaid public_token
-func (c Client) CreateBankAccountWithPlaidLink(ctx context.Context, accountID string, plaid PlaidLink) (*BankAccount, error) {
-	payload := BankAccountPayload{
-		PlaidLink: &plaid,
-	}
-	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodPost, pathBankAccounts, accountID),
-		AcceptJson(),
-		JsonBody(payload))
-	if err != nil {
-		return nil, err
-	}
-
-	switch resp.Status() {
-	case StatusCompleted:
-		return CompletedObjectOrError[BankAccount](resp)
-	case StatusStateConflict:
-		return nil, ErrDuplicateBankAccount
-	default:
-		return nil, resp.Error()
-	}
-}
-
-// CreateBankAccountWithMX creates a new bank account for the given customer account using MX account
-func (c Client) CreateBankAccountWithMX(ctx context.Context, accountID string, mx MX) (*BankAccount, error) {
-	payload := BankAccountPayload{
-		MX: &mx,
-	}
-	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodPost, pathBankAccounts, accountID),
-		AcceptJson(),
-		JsonBody(payload))
-	if err != nil {
-		return nil, err
-	}
-
-	switch resp.Status() {
-	case StatusCompleted:
-		return CompletedObjectOrError[BankAccount](resp)
-	case StatusStateConflict:
-		return nil, ErrDuplicateBankAccount
-	default:
-		return nil, resp.Error()
 	}
 }

--- a/pkg/moov/bank_account.go
+++ b/pkg/moov/bank_account.go
@@ -1,7 +1,9 @@
 package moov
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -80,15 +82,59 @@ type MX struct {
 	AuthorizationCode string `json:"authorizationCode"`
 }
 
+type CreateBankAccountType callArg
+
+func WithBankAccount(bankAccount BankAccount) CreateBankAccountType {
+	return callBuilderFn((func(call *callBuilder) error {
+		bankAccountJSON, err := json.Marshal(bankAccount)
+		if err != nil {
+			return err
+		}
+		call.body = bytes.NewReader(bankAccountJSON)
+		return nil
+	}))
+}
+
+func WithPlaidLink(plaidLink PlaidLink) CreateBankAccountType {
+	return callBuilderFn((func(call *callBuilder) error {
+		bankAccountJSON, err := json.Marshal(plaidLink)
+		if err != nil {
+			return err
+		}
+		call.body = bytes.NewReader(bankAccountJSON)
+		return nil
+	}))
+}
+
+func WithPlaid(plaid Plaid) CreateBankAccountType {
+	return callBuilderFn((func(call *callBuilder) error {
+		bankAccountJSON, err := json.Marshal(plaid)
+		if err != nil {
+			return err
+		}
+		call.body = bytes.NewReader(bankAccountJSON)
+		return nil
+	}))
+}
+
+func WithMX(mx MX) CreateBankAccountType {
+	return callBuilderFn((func(call *callBuilder) error {
+		bankAccountJSON, err := json.Marshal(mx)
+		if err != nil {
+			return err
+		}
+		call.body = bytes.NewReader(bankAccountJSON)
+		return nil
+	}))
+}
+
 // CreateBankAccount creates a new bank account for the given customer account
-func (c Client) CreateBankAccount(ctx context.Context, accountID string, bankAccount BankAccount) (*BankAccount, error) {
-	payload := BankAccountPayload{
-		Account: &bankAccount,
-	}
+func (c Client) CreateBankAccount(ctx context.Context, accountID string, opts ...CreateBankAccountType) (*BankAccount, error) {
+	args := prependArgs(opts, AcceptJson())
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathBankAccounts, accountID),
 		AcceptJson(),
-		JsonBody(payload))
+		JsonBody(args))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/moov/bank_account.go
+++ b/pkg/moov/bank_account.go
@@ -97,13 +97,6 @@ func WithBankAccount(bankAccount BankAccount) CreateBankAccountType {
 
 func WithPlaidLink(plaidLink PlaidLink) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		// need to use a map to add the top level "plaidLink" json key. expected format is:
-		//	{
-		// 		"plaidLink": {
-		// 			"publicToken": "insert token"
-		// 		}
-		// 	}
-
 		plaidLinkMap := map[string]PlaidLink{
 			"plaidLink": plaidLink,
 		}
@@ -118,13 +111,6 @@ func WithPlaidLink(plaidLink PlaidLink) CreateBankAccountType {
 
 func WithPlaid(plaid Plaid) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		// need to use a map to add the top level "plaid" json key. expected format is:
-		//	{
-		// 		"plaid": {
-		// 			"token": "insert token"
-		// 		}
-		// 	}
-
 		plaidMap := map[string]Plaid{
 			"plaid": plaid,
 		}
@@ -139,13 +125,6 @@ func WithPlaid(plaid Plaid) CreateBankAccountType {
 
 func WithMX(mx MX) CreateBankAccountType {
 	return callBuilderFn((func(call *callBuilder) error {
-		// need to use a map to add the top level "mx" json key. expected format is:
-		//	{
-		// 		"mx": {
-		// 			"authorizationCode": "testing"
-		// 		}
-		// 	}
-
 		mxMap := map[string]MX{
 			"mx": mx,
 		}

--- a/pkg/moov/bank_account_test.go
+++ b/pkg/moov/bank_account_test.go
@@ -85,7 +85,7 @@ func (s *BankAccountTestSuite) SetupSuite() {
 		RoutingNumber:   "273976369",
 	}
 
-	result, err := mc.CreateBankAccount(context.Background(), s.accountID, bankAccount)
+	result, err := mc.CreateBankAccount(context.Background(), s.accountID, moov.WithBankAccount(bankAccount))
 	s.NoError(err)
 	s.NotNil(result)
 	bankAccount = *result
@@ -101,7 +101,7 @@ func (s *BankAccountTestSuite) SetupSuite() {
 		RoutingNumber:   "273976369",
 	}
 
-	result, err = mc.CreateBankAccount(context.Background(), s.accountID, bankAccountDelete)
+	result, err = mc.CreateBankAccount(context.Background(), s.accountID, moov.WithBankAccount(bankAccountDelete))
 	s.NoError(err)
 	s.NotNil(result)
 	bankAccount = *result
@@ -133,7 +133,7 @@ func (s *BankAccountTestSuite) TestCreateBankAccount() {
 
 	mc := NewTestClient(s.T())
 
-	result, err := mc.CreateBankAccount(context.Background(), s.accountID, bankAccount)
+	result, err := mc.CreateBankAccount(context.Background(), s.accountID, moov.WithBankAccount(bankAccount))
 	s.NoError(err)
 	s.NotNil(result)
 
@@ -146,11 +146,34 @@ func (s *BankAccountTestSuite) TestCreateBankAccountWithPlaid() {
 	plaid := moov.Plaid{
 		Token: "fake-token",
 	}
-	result, err := mc.CreateBankAccountWithPlaid(context.Background(), s.accountID, plaid)
+	result, err := mc.CreateBankAccount(context.Background(), s.accountID, moov.WithPlaid(plaid))
 	s.NoError(err)
 	s.NotNil(result)
 	s.Equal("1111222233330000", result.AccountNumber)
 }
+
+func (s *BankAccountTestSuite) TestCreateBankAccountWithPlaidLink() {
+	mc := NewTestClient(s.T())
+	plaidLink := moov.PlaidLink{
+		PublicToken: "fake-public-token",
+	}
+	result, err := mc.CreateBankAccount(context.Background(), s.accountID, moov.WithPlaidLink(plaidLink))
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("1111222233330000", result.AccountNumber)
+}
+
+func (s *BankAccountTestSuite) TestCreateBankAccountWithMX() {
+	mc := NewTestClient(s.T())
+	mxToken := moov.MX{
+		AuthorizationCode: "fake-authorization-code",
+	}
+	result, err := mc.CreateBankAccount(context.Background(), s.accountID, moov.WithMX(mxToken))
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("1111222233330000", result.AccountNumber)
+}
+
 func (s *BankAccountTestSuite) TestGetBankAccount() {
 	mc := NewTestClient(s.T())
 	account, err := mc.GetBankAccount(context.Background(), s.accountID, s.bankAccountID)

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -34,6 +34,7 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 		qry.Add(k, v)
 	}
 	req.URL.RawQuery = qry.Encode()
+
 	for k, v := range call.headers {
 		req.Header.Add(k, v)
 	}
@@ -43,13 +44,7 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 	} else {
 		req.SetBasicAuth(c.Credentials.PublicKey, c.Credentials.SecretKey)
 	}
-	/** debug
-	reqDump, err := httputil.DumpRequestOut(req, true)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("REQUEST:\n%s", string(reqDump))
-	**/
+
 	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -57,8 +52,6 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
-	// debug
-	//log.Printf("body: %s \n", body)
 
 	return &httpCallResponse{
 		resp: resp,


### PR DESCRIPTION
Trying a nice way to support Plaid, PlaidLink, MX, and manual bank account creation that all respond with a bank account.

```go
// with bank account
bankAccount := moov.BankAccount{
  HolderName:      "Jules Jackson",
  HolderType:      "individual",
  BankAccountType: "checking",
  AccountNumber:   randomBankAccountNumber(),
  RoutingNumber:   "273976369",
}
result, err := mc.CreateBankAccount(ctx, accountID, moov.WithBankAccount(bankAccount))

// with plaid
plaid := moov.Plaid{
  Token: "fake-token",
}
result, err := mc.CreateBankAccount(ctx, accountID, moov.WithPlaid(plaid))

// with plaid link
plaidLink := moov.PlaidLink{
  PublicToken: "fake-public-token",
}
result, err := mc.CreateBankAccount(ctx, accountID, moov.WithPlaidLink(plaidLink))

// with mx
mxToken := moov.MX{
  AuthorizationCode: "fake-authorization-code",
}
result, err := mc.CreateBankAccount(ctx, accountID, moov.WithMX(mxToken))
```