### PR TITLE
test: set env overrides in each test

### DIFF
--- a/pkg/moov/client_test.go
+++ b/pkg/moov/client_test.go
@@ -3,6 +3,7 @@ package moov_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
@@ -11,18 +12,23 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func init() {
-	// If we don't have the environment variables set due to running in an IDE or directly via the go command, load it up here
-	if _, ok := os.LookupEnv(moov.ENV_MOOV_SECRET_KEY); !ok {
-		godotenv.Load("../../secrets.env")
-	}
-}
-
 func BgCtx() context.Context {
 	return context.Background()
 }
 
-func NewTestClient(t require.TestingT, c ...moov.ClientConfigurable) *moov.Client {
+func NewTestClient(t testing.TB, c ...moov.ClientConfigurable) *moov.Client {
+	// If we have a secrets.env file written read that and populate the test environment
+	secretsPath := filepath.Join("..", "..", "secrets.env")
+
+	if _, err := os.Stat(secretsPath); err == nil {
+		secrets, err := godotenv.Read(secretsPath)
+		require.NoError(t, err)
+
+		for k, v := range secrets {
+			t.Setenv(k, v)
+		}
+	}
+
 	mc, err := moov.NewClient(c...)
 	require.NoError(t, err)
 

--- a/secrets-template.env
+++ b/secrets-template.env
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Copy this to a file to secrets.env and update the variables.
+# Copy this to a file called secrets.env in the root of moov-go and update the variables.
+#
 # This will allow the IDEs and Make load up environment variables for this proejct.
-# This is useful for local development and testing of the SDK. Use the environment variables for production. 
+# This is useful for local development and testing of the SDK. Use the environment variables for production.
 
 MOOV_PUBLIC_KEY="public key here"
 MOOV_SECRET_KEY="secret key here"


### PR DESCRIPTION
Previously I was not seeing `secrets.env` override the API keys I've got already setup. The moov-go specific keys not being chosen caused tests to fail. This setup is much more reliable and keeps overrides to each test. 