### PR TITLE
alternative-1: Separate methods for creating sync vs async transfer and simplify return params

### DIFF
--- a/examples/ach/credit_external_bank/micro_deposits_test.go
+++ b/examples/ach/credit_external_bank/micro_deposits_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-faker/faker/v4"
-	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
 // Sets up an account with linked bank account to be debited via ACH
@@ -96,7 +97,7 @@ func TestMicroDepositExample(t *testing.T) {
 	destinationPaymentMethod := paymentMethods[0]
 
 	// Step 6: create transfer
-	completedTransfer, _, err := mc.CreateTransfer(
+	completedTransfer, _, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -112,7 +113,7 @@ func TestMicroDepositExample(t *testing.T) {
 		},
 		// not required since ACH is processed in batches,
 		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
+		moov.withTransferWaitFor(),
 	)
 	require.NoError(t, err)
 

--- a/examples/ach/debit_bank_account/micro_deposits_test.go
+++ b/examples/ach/debit_bank_account/micro_deposits_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-faker/faker/v4"
-	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
 // Sets up an account with linked bank account to be debited via ACH
@@ -97,7 +98,7 @@ func TestMicroDepositExample(t *testing.T) {
 	destinationPaymentMethod := paymentMethods[0]
 
 	// Step 6: create transfer
-	completedTransfer, _, err := mc.CreateTransfer(
+	completedTransfer, _, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -113,7 +114,7 @@ func TestMicroDepositExample(t *testing.T) {
 		},
 		// not required since ACH is processed in batches,
 		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
+		moov.withTransferWaitFor(),
 	)
 	require.NoError(t, err)
 

--- a/examples/ach/debit_bank_account/plaid_processors_test.go
+++ b/examples/ach/debit_bank_account/plaid_processors_test.go
@@ -94,7 +94,7 @@ func TestPlaidProcessorExample(t *testing.T) {
 	destinationPaymentMethod := paymentMethods[0]
 
 	// Step 6: create transfer
-	completedTransfer, _, err := mc.CreateTransfer(
+	completedTransfer, _, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -110,7 +110,7 @@ func TestPlaidProcessorExample(t *testing.T) {
 		},
 		// not required since ACH is processed in batches,
 		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
+		moov.withTransferWaitFor(),
 	)
 	require.NoError(t, err)
 

--- a/examples/card_acquiring/checkout/checkout_example.go
+++ b/examples/card_acquiring/checkout/checkout_example.go
@@ -96,7 +96,7 @@ func main() {
 	}
 	// Use this token in the card or bank account linking Drop.
 	// Token's allow the browser to link cards and bank accounts to the account directly with Moov.
-	//fmt.Println(completedAccount.AccountID) // cardInput.AccountID
+	// fmt.Println(completedAccount.AccountID) // cardInput.AccountID
 	fmt.Println(token.AccessToken) // cardInput.AccessToken
 
 	// The drop's onSuccess event for the card linking drop returns a Card object the cardID and paymentMethodID
@@ -163,13 +163,13 @@ func main() {
 	description := "Pay Instructor for May 15 Class"
 
 	// Create a transfer from the card to the wallet
-	completedTransfer, _, err := mc.CreateTransfer(context.Background(), moov.CreateTransfer{
+	completedTransfer, _, err := mc.createTransfer(context.Background(), moov.CreateTransfer{
 		Source:         source,
 		Destination:    destination,
 		Amount:         amount,
 		FacilitatorFee: facilitatorFee,
 		Description:    description,
-	}, moov.WithTransferWaitForRailResponse())
+	}, moov.withTransferWaitFor())
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/debit_card_pull/debit_pull_test.go
+++ b/examples/debit_card_pull/debit_pull_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-faker/faker/v4"
-	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
 // Pull transfer is a transfer from the user's card to the Moov wallet.
@@ -95,7 +96,7 @@ func TestDebitPullWithRefund(t *testing.T) {
 	destinationPaymentMethod := paymentMethods[0]
 
 	// Step 6: create transfer
-	completedTransfer, _, err := mc.CreateTransfer(
+	completedTransfer, _, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -116,7 +117,7 @@ func TestDebitPullWithRefund(t *testing.T) {
 			},
 			Description: "Pull from card",
 		},
-		moov.WithTransferWaitForRailResponse(),
+		moov.withTransferWaitFor(),
 	)
 	require.NoError(t, err)
 

--- a/examples/debit_card_push/debit_push_test.go
+++ b/examples/debit_card_push/debit_push_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/go-faker/faker/v4"
-	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
 func TestVisaSandboxPush(t *testing.T) {
@@ -96,7 +97,7 @@ func TestVisaSandboxPush(t *testing.T) {
 	sourcePaymentMethod := paymentMethods[0]
 
 	// Step 6: create transfer
-	completedTransfer, _, err := mc.CreateTransfer(
+	completedTransfer, _, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -117,7 +118,7 @@ func TestVisaSandboxPush(t *testing.T) {
 			},
 			Description: "Push to card",
 		},
-		moov.WithTransferWaitForRailResponse(),
+		moov.withTransferWaitFor(),
 	)
 	require.NoError(t, err)
 

--- a/examples/rtp/rtp_credit_test.go
+++ b/examples/rtp/rtp_credit_test.go
@@ -74,7 +74,7 @@ func TestRTPCreditExample(t *testing.T) {
 	destinationPaymentMethod := destinationPaymentMethods[0]
 
 	// Step 6: create transfer
-	_, completedAsyncTransfer, err := mc.CreateTransfer(
+	_, completedAsyncTransfer, err := mc.createTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{

--- a/pkg/moov/transfer_test.go
+++ b/pkg/moov/transfer_test.go
@@ -3,8 +3,9 @@ package moov_test
 import (
 	"testing"
 
-	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
 func Test_Transfers(t *testing.T) {
@@ -29,7 +30,7 @@ func Test_Transfers(t *testing.T) {
 	source, dest := paymentMethodsFromOptions(t, options, moov.PaymentMethodType_AchDebitFund, moov.PaymentMethodType_MoovWallet)
 
 	t.Run("make async transfer", func(t *testing.T) {
-		completed, started, err := mc.CreateTransfer(BgCtx(), moov.CreateTransfer{
+		completed, started, err := mc.createTransfer(BgCtx(), moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
 				PaymentMethodID: source,
 			},
@@ -49,7 +50,7 @@ func Test_Transfers(t *testing.T) {
 	})
 
 	t.Run("make sync transfer", func(t *testing.T) {
-		completed, started, err := mc.CreateTransfer(BgCtx(), moov.CreateTransfer{
+		completed, started, err := mc.createTransfer(BgCtx(), moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
 				PaymentMethodID: source,
 			},
@@ -60,7 +61,7 @@ func Test_Transfers(t *testing.T) {
 				Currency: "usd",
 				Value:    1,
 			},
-		}, moov.WithTransferWaitForRailResponse())
+		}, moov.withTransferWaitFor())
 		NoResponseError(t, err)
 
 		// We made an async transfer, so completed should be nil, while started not nil


### PR DESCRIPTION
Note: I expect compile to fail, this is my suggestion as a PoC. I will clean up the code/naming if we move forward with this PR.

### Problem
Currently the `CreateTransfer` method returns 3 params `(*Transfer, *TransferStarted, error)`. Why we need to do this is explained in [our docs' response code section](https://docs.moov.io/api/money-movement/transfers/create/#headers).

Whether `*Transfer` or `*TransferStarted` is set/not-nil depends on whether `WithTransferWaitFor` is set, which can be confusing for customers using this client.

### Suggestion
Introduce separate methods for creating an async or sync transfer.

This is best demonstrated in an example:
```go
/** Current implementation **/
transfer, transferStarted, err := client.CreateTransfer(ctx, createTransfer, WithTransferWaitFor())
if err != nil {..}

if transfer != nil {
   // do something with the hydrated Transfer model
} else if transferStarted != nil { 
  // do something with the slimmed down TransferStarted model
}


/** With suggestion **/
// Create async transfer
transferStarted, err := client.CreateTransferAsync(ctx, createTransfer)
if err != nil {..}

// Create sync transfer
transfer, err := client.CreateTransferSync(ctx, createTransfer)
if err != nil {
..
// If timeout occurs, they can check the error and transform it using the errors.As construct:
var timeoutErr CreateTransferTimeoutError
  if errors.As(err, &timeoutErr) {
     // access timeoutErr.TransferStarted
  }
}




```

Resolving LEDG-2676
