### PR TITLE
alternative-2: Condense CreateTransfer return params into one

### DIFF
--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -75,11 +75,11 @@ type CreateTransfer_FacilitatorFee struct {
 	MarkupDecimal *string `json:"markupDecimal,omitempty"`
 }
 
-// TransferStarted is where the request to create a transfer was recorded and kicked off but hasn't completed yet
-type TransferStarted struct {
-	// Identifier for the transfer.
+type TransferCreated struct {
 	TransferID string    `json:"transferID,omitempty"`
 	CreatedOn  time.Time `json:"createdOn,omitempty"`
+	// Fully hydrated transfer, can be nil if X-Wait-For was not set to rail-response or timeout occurred.
+	Transfer *Transfer `json:"transfer,omitempty"`
 }
 
 // Transfer struct for Transfer


### PR DESCRIPTION
For full context on problem and first alternative: [link](https://github.com/moovfinancial/moov-go/pull/94)

`transferID` and `createdOn` will always be set, regardless of whether the response was sync/async or `200/201/202`. Knowing this, we can return a single struct in the `CreateTransfer` method; and only set the hydrated Transfer model if we know the request was synchronous **and** resulted in `200`.

This reduces ambiguity in which return params are not-nil in **all cases**; and the caller only needs to check the `TransferCreated.Transfer` model is not nil in cases when they are making a sync request.

Resolving LEDG-2676