### PR TITLE
webhooks: add signature check

### DIFF
--- a/examples/webhooks/webhooks_test.go
+++ b/examples/webhooks/webhooks_test.go
@@ -16,20 +16,28 @@ import (
 	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
-func TestNewEvent(t *testing.T) {
-	accountCreated := mhooks.AccountCreated{
-		AccountID: uuid.NewString(),
-	}
+func TestParseEvent(t *testing.T) {
+	var (
+		timestamp = "2024-04-26T21:20:55Z"
+		secret    = "my-webhook-signing-secret"
+		signature = "6231d03752de6963087e6aea1c78a27a0617b6df1c071195f30ed85defe34e02fd0bf3995949fe12dafd747c42de9cfae03b8aafcf69cceba5495f4c7b719d82"
 
-	transferCreated := mhooks.TransferCreated{
-		AccountID:  accountCreated.AccountID,
-		TransferID: uuid.NewString(),
-		Status:     moov.TransferStatus_Created,
-	}
+		accountCreated = mhooks.AccountCreated{
+			AccountID: uuid.NewString(),
+		}
+
+		transferCreated = mhooks.TransferCreated{
+			AccountID:  accountCreated.AccountID,
+			TransferID: uuid.NewString(),
+			Status:     moov.TransferStatus_Created,
+		}
+	)
+	createdOn, err := time.Parse(time.RFC3339, timestamp)
+	require.NoError(t, err)
 
 	// Initialize the HTTP handler func for the target webhook URL
 	webhookHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
-		event, err := mhooks.NewEvent(r.Body)
+		event, err := mhooks.ParseEvent(r, secret)
 		require.NoError(t, err)
 
 		//nolint:exhaustive
@@ -50,8 +58,6 @@ func TestNewEvent(t *testing.T) {
 
 		w.WriteHeader(200)
 	}
-
-	rec := httptest.NewRecorder()
 
 	for i, tt := range []struct {
 		eventType mhooks.EventType
@@ -74,7 +80,7 @@ func TestNewEvent(t *testing.T) {
 				EventID:   uuid.NewString(),
 				EventType: tt.eventType,
 				Data:      dataBytes,
-				CreatedOn: time.Now().UTC(),
+				CreatedOn: createdOn,
 			}
 
 			var body bytes.Buffer
@@ -82,6 +88,12 @@ func TestNewEvent(t *testing.T) {
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodPost, "/my-awesome-webhook-url", &body)
+			req.Header.Set("x-timestamp", timestamp)
+			req.Header.Set("x-nonce", "LwxF1Uk7QOeDq2nzB3theslHbtAo7y3uuncB1PoijwCZZaRZsd8DOtffBT7p")
+			req.Header.Set("x-webhook-id", "dff0a709-f982-4475-81e8-214b435c74ab")
+			req.Header.Set("x-signature", signature)
+
+			rec := httptest.NewRecorder()
 			webhookHandlerFunc(rec, req)
 		})
 	}

--- a/pkg/mhooks/signature.go
+++ b/pkg/mhooks/signature.go
@@ -1,0 +1,40 @@
+package mhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"net/http"
+)
+
+func checkSignature(headers http.Header, secret string) (bool, error) {
+	var (
+		timestamp = headers.Get("x-timestamp")
+		nonce     = headers.Get("x-nonce")
+		webhookID = headers.Get("x-webhook-id")
+		gotHash   = headers.Get("x-signature")
+	)
+
+	concatHeaders := timestamp + "|" + nonce + "|" + webhookID
+	wantHash, err := hash([]byte(concatHeaders), []byte(secret))
+	if err != nil {
+		return false, err
+	}
+
+	if *wantHash == gotHash {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+// hash generates a SHA512 HMAC hash of p using the secret provided.
+func hash(p []byte, secret []byte) (*string, error) {
+	h := hmac.New(sha512.New, secret)
+	_, err := h.Write(p)
+	if err != nil {
+		return nil, err
+	}
+	hash := hex.EncodeToString(h.Sum(nil))
+	return &hash, nil
+}


### PR DESCRIPTION
Note: branched off of #97 

**Changes**
1. Add signature check to ParseEvent
2. Update test in `examples/webhooks_test.go`