### PR TITLE
Create actual examples in examples package and move unit tests to mhooks

### DIFF
--- a/examples/webhooks/webhooks_test.go
+++ b/examples/webhooks/webhooks_test.go
@@ -1,100 +1,67 @@
 package webhooks
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
-
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 
 	"github.com/moovfinancial/moov-go/pkg/mhooks"
-	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
-func TestParseEvent(t *testing.T) {
-	var (
-		timestamp = "2024-04-26T21:20:55Z"
-		secret    = "my-webhook-signing-secret"
-		signature = "6231d03752de6963087e6aea1c78a27a0617b6df1c071195f30ed85defe34e02fd0bf3995949fe12dafd747c42de9cfae03b8aafcf69cceba5495f4c7b719d82"
-
-		accountCreated = mhooks.AccountCreated{
-			AccountID: uuid.NewString(),
-		}
-
-		transferCreated = mhooks.TransferCreated{
-			AccountID:  accountCreated.AccountID,
-			TransferID: uuid.NewString(),
-			Status:     moov.TransferStatus_Created,
-		}
-	)
-	createdOn, err := time.Parse(time.RFC3339, timestamp)
-	require.NoError(t, err)
-
-	// Initialize the HTTP handler func for the target webhook URL
-	webhookHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
+// Example handler func for processing a single event type (AccountCreated)
+func ExampleHandler_SingleEvent() {
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		secret := "your-webhook-signing-secret" // fetched from secure storage
 		event, err := mhooks.ParseEvent(r, secret)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+
+		accountCreated, err := event.AccountCreated()
+		if err != nil {
+			w.WriteHeader(500)
+			return
+		}
+
+		fmt.Printf("Got AccountCreated webhook with accountID=%v\n", accountCreated.AccountID)
+		w.WriteHeader(200)
+	}
+
+	err := http.ListenAndServe(":8080", handler)
+	log.Fatal(err)
+}
+
+// Example handler func for processing multiple event types (TransferCreated or TransferUpdated)
+func ExampleHandler_MultipleEvents() {
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		secret := "your-webhook-signing-secret" // fetched from secure storage
+		event, err := mhooks.ParseEvent(r, secret)
+		if err != nil {
+			w.WriteHeader(500)
+		}
 
 		//nolint:exhaustive
 		switch event.EventType {
-		case mhooks.EventTypeAccountCreated:
-			got, err := event.AccountCreated()
-			require.NoError(t, err)
-
-			t.Logf("Got AccountCreated webhook with accountID=%v", got.AccountID)
-			require.Equal(t, accountCreated, *got)
 		case mhooks.EventTypeTransferCreated:
 			got, err := event.TransferCreated()
-			require.NoError(t, err)
-
-			t.Logf("Got TransferCreated webhook with transferID=%v\n", got.TransferID)
-			require.Equal(t, transferCreated, *got)
+			if err != nil {
+				w.WriteHeader(500)
+				return
+			}
+			fmt.Printf("Got TransferCreated webhook with transferID=%v\n", got.TransferID)
+		case mhooks.EventTypeTransferUpdated:
+			got, err := event.TransferUpdated()
+			if err != nil {
+				w.WriteHeader(500)
+				return
+			}
+			fmt.Printf("Got TransferUpdated webhook with transferID=%v\n", got.TransferID)
 		}
 
 		w.WriteHeader(200)
 	}
 
-	for i, tt := range []struct {
-		eventType mhooks.EventType
-		data      any
-	}{
-		{
-			eventType: mhooks.EventTypeAccountCreated,
-			data:      accountCreated,
-		},
-		{
-			eventType: mhooks.EventTypeTransferCreated,
-			data:      transferCreated,
-		},
-	} {
-		t.Run(fmt.Sprintf("%d %v", i, tt.eventType), func(t *testing.T) {
-			dataBytes, err := json.Marshal(tt.data)
-			require.NoError(t, err)
-
-			event := mhooks.Event{
-				EventID:   uuid.NewString(),
-				EventType: tt.eventType,
-				Data:      dataBytes,
-				CreatedOn: createdOn,
-			}
-
-			var body bytes.Buffer
-			err = json.NewEncoder(&body).Encode(event)
-			require.NoError(t, err)
-
-			req := httptest.NewRequest(http.MethodPost, "/my-awesome-webhook-url", &body)
-			req.Header.Set("x-timestamp", timestamp)
-			req.Header.Set("x-nonce", "LwxF1Uk7QOeDq2nzB3theslHbtAo7y3uuncB1PoijwCZZaRZsd8DOtffBT7p")
-			req.Header.Set("x-webhook-id", "dff0a709-f982-4475-81e8-214b435c74ab")
-			req.Header.Set("x-signature", signature)
-
-			rec := httptest.NewRecorder()
-			webhookHandlerFunc(rec, req)
-		})
-	}
+	err := http.ListenAndServe(":8080", handler)
+	log.Fatal(err)
 }

--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -62,6 +62,20 @@ func (p Event) TransferCreated() (*TransferCreated, error) {
 	return &transferCreated, nil
 }
 
+func (p Event) TransferUpdated() (*TransferUpdated, error) {
+	if p.EventType != EventTypeTransferUpdated {
+		return nil, newInvalidEventTypeError(p.EventType, EventTypeTransferUpdated)
+	}
+
+	var transferUpdated TransferUpdated
+	err := json.Unmarshal(p.Data, &transferUpdated)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling TransferUpdated: %w", err)
+	}
+
+	return &transferUpdated, nil
+}
+
 func newInvalidEventTypeError(expected, got EventType) error {
 	return fmt.Errorf("invalid event type: expected %v but got %v", expected, got)
 }

--- a/pkg/mhooks/event_test.go
+++ b/pkg/mhooks/event_test.go
@@ -1,0 +1,99 @@
+package mhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+func TestParseEvent(t *testing.T) {
+	var (
+		timestamp = "2024-04-26T21:20:55Z"
+		secret    = "my-webhook-signing-secret"
+		signature = "6231d03752de6963087e6aea1c78a27a0617b6df1c071195f30ed85defe34e02fd0bf3995949fe12dafd747c42de9cfae03b8aafcf69cceba5495f4c7b719d82"
+
+		accountCreated = AccountCreated{
+			AccountID: uuid.NewString(),
+		}
+
+		transferCreated = TransferCreated{
+			AccountID:  accountCreated.AccountID,
+			TransferID: uuid.NewString(),
+			Status:     moov.TransferStatus_Created,
+		}
+	)
+	createdOn, err := time.Parse(time.RFC3339, timestamp)
+	require.NoError(t, err)
+
+	// Initialize the HTTP handler func for the target webhook URL
+	webhookHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
+		event, err := ParseEvent(r, secret)
+		require.NoError(t, err)
+
+		//nolint:exhaustive
+		switch event.EventType {
+		case EventTypeAccountCreated:
+			got, err := event.AccountCreated()
+			require.NoError(t, err)
+
+			t.Logf("Got AccountCreated webhook with accountID=%v", got.AccountID)
+			require.Equal(t, accountCreated, *got)
+		case EventTypeTransferCreated:
+			got, err := event.TransferCreated()
+			require.NoError(t, err)
+
+			t.Logf("Got TransferCreated webhook with transferID=%v\n", got.TransferID)
+			require.Equal(t, transferCreated, *got)
+		}
+
+		w.WriteHeader(200)
+	}
+
+	for i, tt := range []struct {
+		eventType EventType
+		data      any
+	}{
+		{
+			eventType: EventTypeAccountCreated,
+			data:      accountCreated,
+		},
+		{
+			eventType: EventTypeTransferCreated,
+			data:      transferCreated,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d %v", i, tt.eventType), func(t *testing.T) {
+			dataBytes, err := json.Marshal(tt.data)
+			require.NoError(t, err)
+
+			event := Event{
+				EventID:   uuid.NewString(),
+				EventType: tt.eventType,
+				Data:      dataBytes,
+				CreatedOn: createdOn,
+			}
+
+			var body bytes.Buffer
+			err = json.NewEncoder(&body).Encode(event)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/my-awesome-webhook-url", &body)
+			req.Header.Set("x-timestamp", timestamp)
+			req.Header.Set("x-nonce", "LwxF1Uk7QOeDq2nzB3theslHbtAo7y3uuncB1PoijwCZZaRZsd8DOtffBT7p")
+			req.Header.Set("x-webhook-id", "dff0a709-f982-4475-81e8-214b435c74ab")
+			req.Header.Set("x-signature", signature)
+
+			rec := httptest.NewRecorder()
+			webhookHandlerFunc(rec, req)
+		})
+	}
+}

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -44,4 +44,22 @@ type TransferCreated struct {
 	Status moov.TransferStatus `json:"status"`
 }
 
+type TransferUpdated struct {
+	// ID of the facilitator account
+	AccountID string `json:"accountID,omitempty"`
+	// ID of the transfer
+	TransferID string `json:"transferID,omitempty"`
+	// Status of the transfer
+	Status      string               `json:"status,omitempty"`
+	Source      PaymentMethodPartial `json:"source,omitempty"`
+	Destination PaymentMethodPartial `json:"destination,omitempty"`
+}
+
+type PaymentMethodPartial struct {
+	// ID of the account
+	AccountID string `json:"accountID,omitempty"`
+	// ID of the payment method
+	PaymentMethodID string `json:"paymentMethodID,omitempty"`
+}
+
 // TODO(vince,4/25/2024): I'll add the rest of the models in upcoming PRs.


### PR DESCRIPTION
Responding to PR feedback [here](https://github.com/moovfinancial/moov-go/pull/98#pullrequestreview-2029608332) from @InfernoJJ -- realizing we should take advantage of [Go example patterns](https://go.dev/blog/examples) for code inside of `examples` directory.

In other words, ensure the code in `examples` looks close to what users would use in `production`.