### PR TITLE
moov: raise query params to their noun level types

### DIFF
--- a/pkg/moov/bank_account_api.go
+++ b/pkg/moov/bank_account_api.go
@@ -32,7 +32,7 @@ func WithMX(mx MXRequest) CreateBankAccountType {
 	})
 }
 
-func WaitForPaymentMethod() callArg {
+func WaitForPaymentMethod() CreateBankAccountType {
 	return WaitFor("payment-method")
 }
 

--- a/pkg/moov/disputes.go
+++ b/pkg/moov/disputes.go
@@ -21,70 +21,70 @@ type Dispute struct {
 
 type DisputeListFilter callArg
 
-func WithDisputeCount(c int) callArg {
+func WithDisputeCount(c int) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["count"] = fmt.Sprintf("%d", c)
 		return nil
 	})
 }
 
-func WithDisputeSkip(c int) callArg {
+func WithDisputeSkip(c int) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["skip"] = fmt.Sprintf("%d", c)
 		return nil
 	})
 }
 
-func WithDisputeResponseStartDate(t time.Time) callArg {
+func WithDisputeResponseStartDate(t time.Time) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["respondStartDateTime"] = t.Format(time.RFC3339)
 		return nil
 	})
 }
 
-func WithDisputeResponseEndDate(t time.Time) callArg {
+func WithDisputeResponseEndDate(t time.Time) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["respondEndDateTime"] = t.Format(time.RFC3339)
 		return nil
 	})
 }
 
-func WithDisputeStatus(s string) callArg {
+func WithDisputeStatus(s string) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["status"] = s
 		return nil
 	})
 }
 
-func WithDisputeMerchantAccountID(id string) callArg {
+func WithDisputeMerchantAccountID(id string) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["merchantAccountID"] = id
 		return nil
 	})
 }
 
-func WithDisputeCardHolderAccountID(id string) callArg {
+func WithDisputeCardHolderAccountID(id string) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["cardholderAccountID"] = id
 		return nil
 	})
 }
 
-func WithDisputeStartDate(t time.Time) callArg {
+func WithDisputeStartDate(t time.Time) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["startDateTime"] = t.Format(time.RFC3339)
 		return nil
 	})
 }
 
-func WithDisputeEndDate(t time.Time) callArg {
+func WithDisputeEndDate(t time.Time) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["endDateTime"] = t.Format(time.RFC3339)
 		return nil
 	})
 }
 
-func WithDisputeOrderBy(orderBy string) callArg {
+func WithDisputeOrderBy(orderBy string) DisputeListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["orderBy"] = orderBy
 		return nil

--- a/pkg/moov/payment_method_api.go
+++ b/pkg/moov/payment_method_api.go
@@ -7,7 +7,7 @@ import (
 
 type PaymentMethodListFilter callArg
 
-func WithPaymentMethodSourceID(id string) callArg {
+func WithPaymentMethodSourceID(id string) PaymentMethodListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["sourceID"] = id
 		return nil
@@ -15,7 +15,7 @@ func WithPaymentMethodSourceID(id string) callArg {
 }
 
 // WithPaymentMethodType filters the payment methods by the payment method type. example: moov-wallet, card-payment, ach-debit-collect
-func WithPaymentMethodType(t string) callArg {
+func WithPaymentMethodType(t string) PaymentMethodListFilter {
 	return callBuilderFn(func(call *callBuilder) error {
 		call.params["paymentMethodType"] = t
 		return nil


### PR DESCRIPTION
This restricts the query params usage to endpoints where they will affect the response. callArg is generic and could be passed anywhere.

Goes in line with some changes from https://github.com/moovfinancial/moov-go/compare/main...ledg-2674#diff-caf877c03a3ddfb0c7c4f1e3621afac6eb86c2d3de6a85db762d9fbcb9db8b73 