### PR TITLE
 webhooks: Add methods for all events and simplify json unmarshalling implementation

### DIFF
--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -41,7 +41,7 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 	case EventTypeBankAccountUpdated:
 		eventData = &event.bankAccountUpdated
 	case EventTypeCardAutoUpdated:
-		eventData = &event.capabilityRequested
+		eventData = &event.cardAutoUpdated
 	case EventTypeCapabilityRequested:
 		eventData = &event.capabilityRequested
 	case EventTypeCapabilityUpdated:

--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -24,56 +24,277 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 		return nil, fmt.Errorf("decoding event: %w", err)
 	}
 
+	var eventData any
+	switch event.EventType {
+	case EventTypeAccountCreated:
+		eventData = &event.accountCreated
+	case EventTypeAccountDeleted:
+		eventData = &event.accountDeleted
+	case EventTypeAccountUpdated:
+		eventData = &event.accountUpdated
+	case EventTypeBalanceUpdated:
+		eventData = &event.balanceUpdated
+	case EventTypeBankAccountCreated:
+		eventData = &event.bankAccountCreated
+	case EventTypeBankAccountDeleted:
+		eventData = &event.bankAccountDeleted
+	case EventTypeBankAccountUpdated:
+		eventData = &event.bankAccountUpdated
+	case EventTypeCardAutoUpdated:
+		eventData = &event.capabilityRequested
+	case EventTypeCapabilityRequested:
+		eventData = &event.capabilityRequested
+	case EventTypeCapabilityUpdated:
+		eventData = &event.capabilityUpdated
+	case EventTypeDisputeCreated:
+		eventData = &event.disputeCreated
+	case EventTypeDisputeUpdated:
+		eventData = &event.disputeUpdated
+	case EventTypeNetworkIDUpdated:
+		eventData = &event.networkIDUpdated
+	case EventTypePaymentMethodDisabled:
+		eventData = &event.paymentMethodDisabled
+	case EventTypePaymentMethodEnabled:
+		eventData = &event.paymentMethodEnabled
+	case EventTypeRefundCreated:
+		eventData = &event.refundCreated
+	case EventTypeRefundUpdated:
+		eventData = &event.refundUpdated
+	case EventTypeRepresentativeCreated:
+		eventData = &event.representativeCreated
+	case EventTypeRepresentativeDeleted:
+		eventData = &event.representativeDeleted
+	case EventTypeRepresentativeUpdated:
+		eventData = &event.representativeUpdated
+	case EventTypeTransferCreated:
+		eventData = &event.transferCreated
+	case EventTypeTransferUpdated:
+		eventData = &event.transferUpdated
+	case EventTypeWalletTransactionUpdated:
+		eventData = &event.walletTransactionUpdated
+	}
+
+	err = json.Unmarshal(event.Data, eventData)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling event data: %w", err)
+	}
+
 	return &event, nil
 }
 
 type Event struct {
 	EventID   string    `json:"eventID"`
 	EventType EventType `json:"type"`
-	Data      []byte    `json:"data"`
 	CreatedOn time.Time `json:"createdOn"`
+	Data      []byte    `json:"data"`
+
+	accountCreated           *AccountCreated
+	accountDeleted           *AccountDeleted
+	accountUpdated           *AccountUpdated
+	balanceUpdated           *BalanceUpdated
+	bankAccountCreated       *BankAccountCreated
+	bankAccountDeleted       *BankAccountDeleted
+	bankAccountUpdated       *BankAccountUpdated
+	cardAutoUpdated          *CardAutoUpdated
+	capabilityRequested      *CapabilityRequested
+	capabilityUpdated        *CapabilityUpdated
+	disputeCreated           *DisputeCreated
+	disputeUpdated           *DisputeUpdated
+	networkIDUpdated         *NetworkIDUpdated
+	paymentMethodDisabled    *PaymentMethodDisabled
+	paymentMethodEnabled     *PaymentMethodEnabled
+	refundCreated            *RefundCreated
+	refundUpdated            *RefundUpdated
+	representativeCreated    *RepresentativeCreated
+	representativeDeleted    *RepresentativeDeleted
+	representativeUpdated    *RepresentativeUpdated
+	transferCreated          *TransferCreated
+	transferUpdated          *TransferUpdated
+	walletTransactionUpdated *WalletTransactionUpdated
 }
 
-func (p Event) AccountCreated() (*AccountCreated, error) {
-	if p.EventType != EventTypeAccountCreated {
-		return nil, newInvalidEventTypeError(p.EventType, EventTypeAccountCreated)
+func (e Event) AccountCreated() (*AccountCreated, error) {
+	if e.EventType != EventTypeAccountCreated {
+		return nil, newInvalidEventTypeError(EventTypeAccountCreated, e.EventType)
 	}
 
-	var accountCreated AccountCreated
-	err := json.Unmarshal(p.Data, &accountCreated)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling AccountCreated: %w", err)
-	}
-
-	return &accountCreated, nil
+	return e.accountCreated, nil
 }
 
-func (p Event) TransferCreated() (*TransferCreated, error) {
-	if p.EventType != EventTypeTransferCreated {
-		return nil, newInvalidEventTypeError(p.EventType, EventTypeTransferCreated)
+func (e Event) AccountDeleted() (*AccountDeleted, error) {
+	if e.EventType != EventTypeAccountDeleted {
+		return nil, newInvalidEventTypeError(EventTypeAccountDeleted, e.EventType)
 	}
 
-	var transferCreated TransferCreated
-	err := json.Unmarshal(p.Data, &transferCreated)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling TransferCreated: %w", err)
-	}
-
-	return &transferCreated, nil
+	return e.accountDeleted, nil
 }
 
-func (p Event) TransferUpdated() (*TransferUpdated, error) {
-	if p.EventType != EventTypeTransferUpdated {
-		return nil, newInvalidEventTypeError(p.EventType, EventTypeTransferUpdated)
+func (e Event) AccountUpdated() (*AccountUpdated, error) {
+	if e.EventType != EventTypeAccountUpdated {
+		return nil, newInvalidEventTypeError(EventTypeAccountUpdated, e.EventType)
 	}
 
-	var transferUpdated TransferUpdated
-	err := json.Unmarshal(p.Data, &transferUpdated)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling TransferUpdated: %w", err)
+	return e.accountUpdated, nil
+}
+
+func (e Event) BalanceUpdated() (*BalanceUpdated, error) {
+	if e.EventType != EventTypeBalanceUpdated {
+		return nil, newInvalidEventTypeError(EventTypeBalanceUpdated, e.EventType)
 	}
 
-	return &transferUpdated, nil
+	return e.balanceUpdated, nil
+}
+
+func (e Event) BankAccountCreated() (*BankAccountCreated, error) {
+	if e.EventType != EventTypeBankAccountCreated {
+		return nil, newInvalidEventTypeError(EventTypeBankAccountCreated, e.EventType)
+	}
+
+	return e.bankAccountCreated, nil
+}
+
+func (e Event) BankAccountDeleted() (*BankAccountDeleted, error) {
+	if e.EventType != EventTypeBankAccountDeleted {
+		return nil, newInvalidEventTypeError(EventTypeBankAccountDeleted, e.EventType)
+	}
+
+	return e.bankAccountDeleted, nil
+}
+
+func (e Event) BankAccountUpdated() (*BankAccountUpdated, error) {
+	if e.EventType != EventTypeBankAccountUpdated {
+		return nil, newInvalidEventTypeError(EventTypeBankAccountUpdated, e.EventType)
+	}
+
+	return e.bankAccountUpdated, nil
+}
+
+func (e Event) CardAutoUpdated() (*CardAutoUpdated, error) {
+	if e.EventType != EventTypeCardAutoUpdated {
+		return nil, newInvalidEventTypeError(EventTypeCardAutoUpdated, e.EventType)
+	}
+
+	return e.cardAutoUpdated, nil
+}
+
+func (e Event) CapabilityRequested() (*CapabilityRequested, error) {
+	if e.EventType != EventTypeCapabilityRequested {
+		return nil, newInvalidEventTypeError(EventTypeCapabilityRequested, e.EventType)
+	}
+
+	return e.capabilityRequested, nil
+}
+
+func (e Event) CapabilityUpdated() (*CapabilityUpdated, error) {
+	if e.EventType != EventTypeCapabilityUpdated {
+		return nil, newInvalidEventTypeError(EventTypeCapabilityUpdated, e.EventType)
+	}
+
+	return e.capabilityUpdated, nil
+}
+
+func (e Event) DisputeCreated() (*DisputeCreated, error) {
+	if e.EventType != EventTypeDisputeCreated {
+		return nil, newInvalidEventTypeError(EventTypeDisputeCreated, e.EventType)
+	}
+
+	return e.disputeCreated, nil
+}
+
+func (e Event) DisputeUpdated() (*DisputeUpdated, error) {
+	if e.EventType != EventTypeDisputeUpdated {
+		return nil, newInvalidEventTypeError(EventTypeDisputeUpdated, e.EventType)
+	}
+
+	return e.disputeUpdated, nil
+}
+
+func (e Event) NetworkIDUpdated() (*NetworkIDUpdated, error) {
+	if e.EventType != EventTypeNetworkIDUpdated {
+		return nil, newInvalidEventTypeError(EventTypeNetworkIDUpdated, e.EventType)
+	}
+
+	return e.networkIDUpdated, nil
+}
+
+func (e Event) PaymentMethodDisabled() (*PaymentMethodDisabled, error) {
+	if e.EventType != EventTypePaymentMethodDisabled {
+		return nil, newInvalidEventTypeError(EventTypePaymentMethodDisabled, e.EventType)
+	}
+
+	return e.paymentMethodDisabled, nil
+}
+
+func (e Event) PaymentMethodEnabled() (*PaymentMethodEnabled, error) {
+	if e.EventType != EventTypePaymentMethodEnabled {
+		return nil, newInvalidEventTypeError(EventTypePaymentMethodEnabled, e.EventType)
+	}
+
+	return e.paymentMethodEnabled, nil
+}
+
+func (e Event) RefundCreated() (*RefundCreated, error) {
+	if e.EventType != EventTypeRefundCreated {
+		return nil, newInvalidEventTypeError(EventTypeRefundCreated, e.EventType)
+	}
+
+	return e.refundCreated, nil
+}
+
+func (e Event) RefundUpdated() (*RefundUpdated, error) {
+	if e.EventType != EventTypeRefundUpdated {
+		return nil, newInvalidEventTypeError(EventTypeRefundUpdated, e.EventType)
+	}
+
+	return e.refundUpdated, nil
+}
+
+func (e Event) RepresentativeCreated() (*RepresentativeCreated, error) {
+	if e.EventType != EventTypeRepresentativeCreated {
+		return nil, newInvalidEventTypeError(EventTypeRepresentativeCreated, e.EventType)
+	}
+
+	return e.representativeCreated, nil
+}
+
+func (e Event) RepresentativeDeleted() (*RepresentativeDeleted, error) {
+	if e.EventType != EventTypeRepresentativeDeleted {
+		return nil, newInvalidEventTypeError(EventTypeRepresentativeDeleted, e.EventType)
+	}
+
+	return e.representativeDeleted, nil
+}
+
+func (e Event) RepresentativeUpdated() (*RepresentativeUpdated, error) {
+	if e.EventType != EventTypeRepresentativeUpdated {
+		return nil, newInvalidEventTypeError(EventTypeRepresentativeUpdated, e.EventType)
+	}
+
+	return e.representativeUpdated, nil
+}
+
+func (e Event) TransferCreated() (*TransferCreated, error) {
+	if e.EventType != EventTypeTransferCreated {
+		return nil, newInvalidEventTypeError(EventTypeTransferCreated, e.EventType)
+	}
+
+	return e.transferCreated, nil
+}
+
+func (e Event) TransferUpdated() (*TransferUpdated, error) {
+	if e.EventType != EventTypeTransferUpdated {
+		return nil, newInvalidEventTypeError(EventTypeTransferUpdated, e.EventType)
+	}
+
+	return e.transferUpdated, nil
+}
+
+func (e Event) WalletTransactionUpdated() (*WalletTransactionUpdated, error) {
+	if e.EventType != EventTypeWalletTransactionUpdated {
+		return nil, newInvalidEventTypeError(EventTypeWalletTransactionUpdated, e.EventType)
+	}
+
+	return e.walletTransactionUpdated, nil
 }
 
 func newInvalidEventTypeError(expected, got EventType) error {


### PR DESCRIPTION
1. Small refactor to implementation; instead of calling `json.Unmarshal` in each getter (e.g. TransferCreated()); we can use a switch and only call it once inside `ParseEvent`.
2. Adds all getter methods for each event type model

---
**Considerations on the API:**

Currently, usage looks like:
```go
		event, err := mhooks.ParseEvent(r, "your-webhook-signing-secret")
		if err != nil {..}

		accountCreated, err := event.AccountCreated()
		if err != nil {..}

		fmt.Printf("Got AccountCreated webhook with accountID=%v\n", accountCreated.AccountID)
		w.WriteHeader(200)
```

But, an **alternative** would be to have the user initialize their expected event model before the call to `ParseEvent`. If they provided the incorrect model, `ParseEvent` will return an error with some helpful context.
```go
                var accountCreated mhooks.AccountCreated
		event, err := mhooks.ParseEvent(r, "your-webhook-signing-secret", &accountCreated)
		if err != nil {..}

		fmt.Printf("Got AccountCreated webhook with accountID=%v\n", accountCreated.AccountID)
		w.WriteHeader(200)
```
Benefit is slightly less error handling to deal with. But the last argument to `ParseEvent` would have to be an an `any/generic` type.