### PR TITLE
alternative-3: have CreateTransfer return intermediary struct to constrain return params based on async or sync call

### DIFF
--- a/examples/ach/credit_external_bank/micro_deposits_test.go
+++ b/examples/ach/credit_external_bank/micro_deposits_test.go
@@ -109,11 +109,7 @@ func TestMicroDepositExample(t *testing.T) {
 				Currency: "USD",
 				Value:    2843, // $28.43
 			},
-		},
-		// not required since ACH is processed in batches,
-		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
-	)
+		}).WaitForRailResponse()
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedTransfer.TransferID)

--- a/examples/ach/debit_bank_account/micro_deposits_test.go
+++ b/examples/ach/debit_bank_account/micro_deposits_test.go
@@ -110,11 +110,11 @@ func TestMicroDepositExample(t *testing.T) {
 				Currency: "USD",
 				Value:    4328, // $43.28
 			},
-		},
+		}).
 		// not required since ACH is processed in batches,
 		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
-	)
+		WaitForRailResponse()
+
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedTransfer.TransferID)

--- a/examples/ach/debit_bank_account/plaid_processors_test.go
+++ b/examples/ach/debit_bank_account/plaid_processors_test.go
@@ -107,11 +107,11 @@ func TestPlaidProcessorExample(t *testing.T) {
 				Currency: "USD",
 				Value:    2717, // $27.17
 			},
-		},
+		}).
 		// not required since ACH is processed in batches,
 		// but useful in getting the full transfer model
-		moov.WithTransferWaitForRailResponse(),
-	)
+		WaitForRailResponse()
+
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedTransfer.TransferID)

--- a/examples/card_acquiring/checkout/checkout_example.go
+++ b/examples/card_acquiring/checkout/checkout_example.go
@@ -169,7 +169,7 @@ func main() {
 		Amount:         amount,
 		FacilitatorFee: facilitatorFee,
 		Description:    description,
-	}, moov.WithTransferWaitForRailResponse())
+	}).WaitForRailResponse()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/debit_card_pull/debit_pull_test.go
+++ b/examples/debit_card_pull/debit_pull_test.go
@@ -115,9 +115,7 @@ func TestDebitPullWithRefund(t *testing.T) {
 				Total: moov.PtrOf(int64(2)), // $0.02
 			},
 			Description: "Pull from card",
-		},
-		moov.WithTransferWaitForRailResponse(),
-	)
+		}).WaitForRailResponse()
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedTransfer.TransferID)

--- a/examples/debit_card_push/debit_push_test.go
+++ b/examples/debit_card_push/debit_push_test.go
@@ -116,9 +116,7 @@ func TestVisaSandboxPush(t *testing.T) {
 				Total: moov.PtrOf(int64(2)), // $0.02
 			},
 			Description: "Push to card",
-		},
-		moov.WithTransferWaitForRailResponse(),
-	)
+		}).WaitForRailResponse()
 	require.NoError(t, err)
 
 	fmt.Printf("Transfer: %+v\n", completedTransfer.TransferID)

--- a/examples/rtp/rtp_credit_ach_fallback_test.go
+++ b/examples/rtp/rtp_credit_ach_fallback_test.go
@@ -88,8 +88,7 @@ func TestRTPCreditACHFallbackExample(t *testing.T) {
 				Currency: "USD",
 				Value:    132, // $1.32
 			},
-		},
-	)
+		}).WaitForRailResponse()
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedAsyncTransfer.TransferID)

--- a/examples/rtp/rtp_credit_test.go
+++ b/examples/rtp/rtp_credit_test.go
@@ -74,7 +74,7 @@ func TestRTPCreditExample(t *testing.T) {
 	destinationPaymentMethod := destinationPaymentMethods[0]
 
 	// Step 6: create transfer
-	_, completedAsyncTransfer, err := mc.CreateTransfer(
+	completedAsyncTransfer, err := mc.CreateTransfer(
 		ctx,
 		moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
@@ -88,7 +88,7 @@ func TestRTPCreditExample(t *testing.T) {
 				Value:    132, // $1.32
 			},
 		},
-	)
+	).Started()
 	require.NoError(t, err)
 
 	t.Logf("Transfer %s created", completedAsyncTransfer.TransferID)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moovfinancial/moov-go
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/go-faker/faker/v4 v4.4.1

--- a/pkg/moov/transfer_api.go
+++ b/pkg/moov/transfer_api.go
@@ -70,7 +70,7 @@ func (r CreateTransferBuilder) Started() (*TransferStarted, error) {
 	}
 }
 
-// Starts a transfer request and then waits for the approval or refusal of the rail before returning the result.
+// Starts a transfer request and waits for a response from the rail (e.g. authorized or declined) before returning the result.
 // This returns 3 results
 // - 1st being a transfer that waited until we got a success or failure from the rail.
 // - 2nd being a transfer that was started but didn't finish before timing out. This response can be retried with the same idempotency key. You may also void or refund using the data from the response.

--- a/pkg/moov/transfer_api.go
+++ b/pkg/moov/transfer_api.go
@@ -52,7 +52,7 @@ type CreateTransferBuilder struct {
 	callArgs []callArg
 }
 
-// Started kicks off the transfers request and doesn't wait beyond the initial response kicking off the transfer
+// Started initiates the transfers request and doesn't wait beyond creating the transfer
 func (r CreateTransferBuilder) Started() (*TransferStarted, error) {
 	resp, err := r.client.CallHttp(r.ctx, r.endpoint, r.callArgs...)
 	if err != nil {

--- a/pkg/moov/transfer_api.go
+++ b/pkg/moov/transfer_api.go
@@ -71,7 +71,7 @@ func (r CreateTransferBuilder) Started() (*TransferStarted, error) {
 }
 
 // Starts a transfer request and waits for a response from the rail (e.g. authorized or declined) before returning the result.
-// The 3 return values are:
+// There are three possible return values (and only one will be not-nil):
 // 1) A full transfer with rail-specific details as a result of waiting for the response from the rail.
 // 2) A transfer that started but the request timed out waiting for a response from the rail.
 // 3) An error attempting to create the transfer.

--- a/pkg/moov/transfer_api.go
+++ b/pkg/moov/transfer_api.go
@@ -71,10 +71,10 @@ func (r CreateTransferBuilder) Started() (*TransferStarted, error) {
 }
 
 // Starts a transfer request and waits for a response from the rail (e.g. authorized or declined) before returning the result.
-// This returns 3 results
-// - 1st being a transfer that waited until we got a success or failure from the rail.
-// - 2nd being a transfer that was started but didn't finish before timing out. This response can be retried with the same idempotency key. You may also void or refund using the data from the response.
-// - 3rd being an error in running the transfer which is a terminal state.
+// The 3 return values are:
+// 1) A full transfer with rail-specific details as a result of waiting for the response from the rail.
+// 2) A transfer that started but the request timed out waiting for a response from the rail.
+// 3) An error attempting to create the transfer.
 func (r CreateTransferBuilder) WaitForRailResponse() (*Transfer, *TransferStarted, error) {
 	resp, err := r.client.CallHttp(r.ctx, r.endpoint, append(r.callArgs, WaitFor("rail-response"))...)
 	if err != nil {

--- a/pkg/moov/transfer_test.go
+++ b/pkg/moov/transfer_test.go
@@ -29,7 +29,7 @@ func Test_Transfers(t *testing.T) {
 	source, dest := paymentMethodsFromOptions(t, options, moov.PaymentMethodType_AchDebitFund, moov.PaymentMethodType_MoovWallet)
 
 	t.Run("make async transfer", func(t *testing.T) {
-		completed, started, err := mc.CreateTransfer(BgCtx(), moov.CreateTransfer{
+		started, err := mc.CreateTransfer(BgCtx(), moov.CreateTransfer{
 			Source: moov.CreateTransfer_Source{
 				PaymentMethodID: source,
 			},
@@ -40,11 +40,10 @@ func Test_Transfers(t *testing.T) {
 				Currency: "usd",
 				Value:    1,
 			},
-		})
+		}).Started()
 		NoResponseError(t, err)
 
 		// We made an async transfer, so completed should be nil, while started not nil
-		require.Nil(t, completed)
 		require.NotNil(t, started)
 	})
 
@@ -60,7 +59,7 @@ func Test_Transfers(t *testing.T) {
 				Currency: "usd",
 				Value:    1,
 			},
-		}, moov.WithTransferWaitForRailResponse())
+		}).WaitForRailResponse()
 		NoResponseError(t, err)
 
 		// We made an async transfer, so completed should be nil, while started not nil


### PR DESCRIPTION
Note: I expect compile to fail, this is my suggestion as a PoC. I will clean up the code/naming if we move forward with this PR.

Previous alternative here: https://github.com/moovfinancial/moov-go/pull/96

### Problem
Currently the `CreateTransfer` method returns 3 params `(*Transfer, *TransferStarted, error)`. Why we need to do this is explained in [our docs' response code section](https://docs.moov.io/api/money-movement/transfers/create/#headers).

Whether `*Transfer` or `*TransferStarted` is set/not-nil depends on whether `WithTransferWaitFor` is set, which can be confusing for customers using this client.

### Suggestion
@InfernoJJ has suggested using an intermediary return struct to constrain the return params based on whether it is an async (started) vs sync (wait for rail-response) call.

This is best demonstrated in an example:
```go
/** Current implementation **/
// Create async transfer
//User will have to know transfer will always be nil based on docs
transfer, transferStarted, err := client.CreateTransfer(ctx, createTransfer)
if err != nil {..}

if transferStarted != nil { 
  // do something with the slimmed down TransferStarted model
}


// Create sync transfer
transfer, transferStarted, err := client.CreateTransfer(ctx, createTransfer, WithTransferWaitFor())
if err != nil {..}

if transfer != nil {
   // do something with the hydrated Transfer model
} else if transferStarted != nil { 
  // do something with the slimmed down TransferStarted model
}

------------------------------------
/** With suggestion **/
// Create async 
transferStarted, err := client.CreateTransfer(ctx, createTransfer).Started()
if err != nil {..}


// Create sync transfer
transfer, transferStarted, err := client.CreateTransfer(ctx, createTransfer).WaitForRailResponse()
if err != nil {..}

if transfer != nil {
   // do something with the hydrated Transfer model
} else if transferStarted != nil { 
  // do something with the slimmed down TransferStarted model
}

```

Resolving LEDG-2676
Fixes https://github.com/moovfinancial/moov-go/issues/60
