### PR TITLE
fix: enforce exact JSON decoding

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  schedule:
+    - cron: "0 12 * * *" # "12:00 UTC" - https://crontab.guru/#0_12_*_*_*e
+  workflow_dispatch:
 
 env:
   MOOV_PUBLIC_KEY: ${{ secrets.MOOV_PUBLIC_KEY }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,3 +57,14 @@ jobs:
       run: make check
       env:
         SKIP_LINTERS: yes
+
+    - name: Report Failure
+      uses: tokorom/action-slack-incoming-webhook@main
+      if: github.event_name == 'schedule' && failure()
+      env:
+        INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        text: |+
+          moov-go CI Failure
+
+          Github Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/pkg/moov/account_models.go
+++ b/pkg/moov/account_models.go
@@ -85,6 +85,11 @@ type TermsOfServiceManual struct {
 	AcceptanceDate      time.Time `json:"acceptedDate"`
 }
 
+type AccountCapability struct {
+	Capability CapabilityName   `json:"capability,omitempty"`
+	Status     CapabilityStatus `json:"status,omitempty"`
+}
+
 // Account Describes a Moov account.
 type Account struct {
 	Mode Mode `json:"mode,omitempty"`
@@ -94,9 +99,10 @@ type Account struct {
 	DisplayName string      `json:"displayName,omitempty"`
 	Profile     Profile     `json:"profile,omitempty"`
 	// Free-form key-value pair list. Useful for storing information that is not captured elsewhere.
-	Metadata       map[string]string `json:"metadata,omitempty"`
-	TermsOfService *TermsOfService   `json:"termsOfService,omitempty"`
-	Verification   Verification      `json:"verification,omitempty"`
+	Metadata       map[string]string   `json:"metadata,omitempty"`
+	TermsOfService *TermsOfService     `json:"termsOfService,omitempty"`
+	Capabilities   []AccountCapability `json:"capabilities,omitempty"`
+	Verification   Verification        `json:"verification,omitempty"`
 	// Optional alias from a foreign/external system which can be used to reference this resource.
 	ForeignID       string           `json:"foreignID,omitempty"`
 	CustomerSupport *CustomerSupport `json:"customerSupport,omitempty"`

--- a/pkg/moov/cards.go
+++ b/pkg/moov/cards.go
@@ -8,23 +8,27 @@ import (
 )
 
 type Card struct {
-	CardID             string             `json:"cardID,omitempty"`
-	Fingerprint        string             `json:"fingerprint,omitempty"`
-	Brand              string             `json:"brand,omitempty"`
-	CardType           string             `json:"cardType,omitempty"`
-	LastFourCardNumber string             `json:"lastFourCardNumber,omitempty"`
-	Bin                string             `json:"bin,omitempty"`
-	Expiration         Expiration         `json:"expiration,omitempty"`
-	HolderName         string             `json:"holderName,omitempty"`
-	BillingAddress     Address            `json:"billingAddress,omitempty"`
-	CardVerification   CardVerification   `json:"cardVerification,omitempty"`
-	Issuer             string             `json:"issuer,omitempty"`
-	IssuerCountry      string             `json:"issuerCountry,omitempty"`
-	CardOnFile         bool               `json:"cardOnFile,omitempty"`
-	MerchantAccountID  string             `json:"merchantAccountID,omitempty"`
-	CardAccountUpdater CardAccountUpdater `json:"cardAccountUpdater,omitempty"`
-	DomesticPushToCard string             `json:"domesticPushToCard,omitempty"`
-	PaymentMethods     []PaymentMethod    `json:"paymentMethods,omitempty"`
+	CardID               string             `json:"cardID,omitempty"`
+	Fingerprint          string             `json:"fingerprint,omitempty"`
+	Brand                string             `json:"brand,omitempty"`
+	CardCategory         string             `json:"cardCategory,omitempty"`
+	CardType             string             `json:"cardType,omitempty"`
+	LastFourCardNumber   string             `json:"lastFourCardNumber,omitempty"`
+	Bin                  string             `json:"bin,omitempty"`
+	Expiration           Expiration         `json:"expiration,omitempty"`
+	HolderName           string             `json:"holderName,omitempty"`
+	BillingAddress       Address            `json:"billingAddress,omitempty"`
+	CardVerification     CardVerification   `json:"cardVerification,omitempty"`
+	Issuer               string             `json:"issuer,omitempty"`
+	IssuerCountry        string             `json:"issuerCountry,omitempty"`
+	IssuerURL            string             `json:"issuerURL,omitempty"`
+	IssuerPhone          string             `json:"issuerPhone,omitempty"`
+	CardOnFile           bool               `json:"cardOnFile,omitempty"`
+	MerchantAccountID    string             `json:"merchantAccountID,omitempty"`
+	CardAccountUpdater   CardAccountUpdater `json:"cardAccountUpdater,omitempty"`
+	DomesticPushToCard   string             `json:"domesticPushToCard,omitempty"`
+	DomesticPullFromCard string             `json:"domesticPullFromCard,omitempty"`
+	PaymentMethods       []PaymentMethod    `json:"paymentMethods,omitempty"`
 }
 
 type Expiration struct {
@@ -33,9 +37,10 @@ type Expiration struct {
 }
 
 type CardVerification struct {
-	Cvv          string `json:"cvv,omitempty"`
-	AddressLine1 string `json:"addressLine1,omitempty"`
-	PostalCode   string `json:"postalCode,omitempty"`
+	Cvv          string                  `json:"cvv,omitempty"`
+	AddressLine1 string                  `json:"addressLine1,omitempty"`
+	PostalCode   string                  `json:"postalCode,omitempty"`
+	AccountName  AccountNameVerification `json:"accountName,omitempty"`
 }
 
 type CardAccountUpdater struct {
@@ -50,6 +55,7 @@ type CardDetails struct {
 	TransactionSource        string            `json:"transactionSource,omitempty"`
 	InterchangeQualification string            `json:"interchangeQualification,omitempty"`
 	StatusUpdates            CardStatusUpdates `json:"statusUpdates,omitempty"`
+	CompletedOn              *time.Time        `json:"completedOn,omitempty"`
 }
 
 type CardStatusUpdates struct {

--- a/pkg/moov/client.go
+++ b/pkg/moov/client.go
@@ -1,12 +1,15 @@
 package moov
 
 import (
+	"io"
 	"net/http"
 )
 
 type Client struct {
 	Credentials Credentials
 	HttpClient  *http.Client
+
+	decoder Decoder
 }
 
 // NewClient returns a moov.Client with credentials read from environment variables.
@@ -44,6 +47,15 @@ func WithCredentials(credentials Credentials) ClientConfigurable {
 func WithHttpClient(client *http.Client) ClientConfigurable {
 	return func(c *Client) error {
 		c.HttpClient = client
+		return nil
+	}
+}
+
+type Decoder func(r io.Reader, item any) error
+
+func WithDecoder(dec Decoder) ClientConfigurable {
+	return func(c *Client) error {
+		c.decoder = dec
 		return nil
 	}
 }

--- a/pkg/moov/client.go
+++ b/pkg/moov/client.go
@@ -51,7 +51,7 @@ func WithHttpClient(client *http.Client) ClientConfigurable {
 	}
 }
 
-type Decoder func(r io.Reader, item any) error
+type Decoder func(r io.Reader, contentType string, item any) error
 
 func WithDecoder(dec Decoder) ClientConfigurable {
 	return func(c *Client) error {

--- a/pkg/moov/client_test.go
+++ b/pkg/moov/client_test.go
@@ -2,6 +2,8 @@ package moov_test
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,12 +31,20 @@ func NewTestClient(t testing.TB, c ...moov.ClientConfigurable) *moov.Client {
 		}
 	}
 
+	c = append(c, moov.WithDecoder(strictDecoder))
+
 	mc, err := moov.NewClient(c...)
 	require.NoError(t, err)
 
 	require.NoError(t, mc.Ping(BgCtx()), "Unable to ping with credentials")
 
 	return mc
+}
+
+func strictDecoder(r io.Reader, item any) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	return dec.Decode(item)
 }
 
 func Test_Client(t *testing.T) {

--- a/pkg/moov/client_test.go
+++ b/pkg/moov/client_test.go
@@ -3,9 +3,11 @@ package moov_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
@@ -41,10 +43,13 @@ func NewTestClient(t testing.TB, c ...moov.ClientConfigurable) *moov.Client {
 	return mc
 }
 
-func strictDecoder(r io.Reader, item any) error {
-	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
-	return dec.Decode(item)
+func strictDecoder(r io.Reader, contentType string, item any) error {
+	if strings.Contains(contentType, "application/json") {
+		dec := json.NewDecoder(r)
+		dec.DisallowUnknownFields()
+		return dec.Decode(item)
+	}
+	return fmt.Errorf("unknown content-type %s", contentType)
 }
 
 func Test_Client(t *testing.T) {

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -123,8 +123,10 @@ func (r *httpCallResponse) Unmarshal(item any) error {
 	}
 
 	if strings.Contains(ct, "json") {
-		// content type checking here...
-		return json.Unmarshal(r.body, item)
+		// TODO: content type checking here...
+		dec := json.NewDecoder(bytes.NewReader(r.body))
+		dec.DisallowUnknownFields()
+		return dec.Decode(item)
 	}
 
 	return fmt.Errorf("unknown content-type: %s", ct)

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -118,8 +118,11 @@ func (r *httpCallResponse) Status() CallStatus {
 	}
 }
 
-func standardDecoder(r io.Reader, item any) error {
-	return json.NewDecoder(r).Decode(item)
+func standardDecoder(r io.Reader, contentType string, item any) error {
+	if strings.Contains(contentType, "application/json") {
+		return json.NewDecoder(r).Decode(item)
+	}
+	return fmt.Errorf("unknown content-type %s", contentType)
 }
 
 func (r *httpCallResponse) Unmarshal(item any) error {
@@ -135,12 +138,7 @@ func (r *httpCallResponse) Unmarshal(item any) error {
 		return err
 	}
 
-	if strings.Contains(ct, "json") {
-		// TODO: content type checking here...
-		return r.decoder(bytes.NewReader(r.body), item)
-	}
-
-	return fmt.Errorf("unknown content-type: %s", ct)
+	return r.decoder(bytes.NewReader(r.body), ct, item)
 }
 
 func (r *httpCallResponse) StatusCode() int {

--- a/pkg/moov/institutions.go
+++ b/pkg/moov/institutions.go
@@ -11,17 +11,24 @@ type FinancialInstitutions struct {
 }
 
 type AchParticipant struct {
-	RoutingNumber      string      `json:"routingNumber,omitempty"`
-	OfficeCode         string      `json:"officeCode,omitempty"`
-	ServicingFRBNumber string      `json:"servicingFRBNumber,omitempty"`
-	RecordTypeCode     string      `json:"recordTypeCode,omitempty"`
-	Revised            string      `json:"revised,omitempty"`
-	NewRoutingNumber   string      `json:"newRoutingNumber,omitempty"`
-	CustomerName       string      `json:"customerName,omitempty"`
-	PhoneNumber        string      `json:"phoneNumber,omitempty"`
-	StatusCode         string      `json:"statusCode,omitempty"`
-	ViewCode           string      `json:"viewCode,omitempty"`
-	AchLocation        AchLocation `json:"achLocation,omitempty"`
+	RoutingNumber      string           `json:"routingNumber,omitempty"`
+	OfficeCode         string           `json:"officeCode,omitempty"`
+	ServicingFRBNumber string           `json:"servicingFRBNumber,omitempty"`
+	RecordTypeCode     string           `json:"recordTypeCode,omitempty"`
+	Revised            string           `json:"revised,omitempty"`
+	NewRoutingNumber   string           `json:"newRoutingNumber,omitempty"`
+	CustomerName       string           `json:"customerName,omitempty"`
+	PhoneNumber        string           `json:"phoneNumber,omitempty"`
+	StatusCode         string           `json:"statusCode,omitempty"`
+	ViewCode           string           `json:"viewCode,omitempty"`
+	CleanName          string           `json:"cleanName,omitempty"`
+	AchLocation        AchLocation      `json:"achLocation,omitempty"`
+	Logo               *InstitutionLogo `json:"logo,omitempty"`
+}
+
+type InstitutionLogo struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
 type AchLocation struct {

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -125,9 +125,10 @@ type CardExpiration struct {
 
 // CardVerifications The results of submitting cardholder data to a card network for verification.
 type CardVerifications struct {
-	Cvv          CardVerificationResult `json:"cvv,omitempty"`
-	AddressLine1 CardVerificationResult `json:"addressLine1,omitempty"`
-	PostalCode   CardVerificationResult `json:"postalCode,omitempty"`
+	Cvv          CardVerificationResult  `json:"cvv,omitempty"`
+	AddressLine1 CardVerificationResult  `json:"addressLine1,omitempty"`
+	PostalCode   CardVerificationResult  `json:"postalCode,omitempty"`
+	AccountName  AccountNameVerification `json:"accountName,omitempty"`
 }
 
 // CardVerificationResult the model 'CardVerificationResult'
@@ -140,6 +141,13 @@ const (
 	CardVerificationResult_NotChecked  CardVerificationResult = "notChecked"
 	CardVerificationResult_Unavailable CardVerificationResult = "unavailable"
 )
+
+type AccountNameVerification struct {
+	FirstName  CardVerificationResult `json:"firstName,omitempty"`
+	LastName   CardVerificationResult `json:"lastName,omitempty"`
+	MiddleName CardVerificationResult `json:"middleName,omitempty"`
+	FullName   CardVerificationResult `json:"fullName,omitempty"`
+}
 
 // DomesticPushToCard Indicates which level of domestic push-to-card transfer is supported by the card, if any.
 type DomesticPushToCard string


### PR DESCRIPTION
We need our SDK to cover the entire Moov API request/response structure. This is a first step towards enforcing that.