### PR TITLE
examples/ach: retry listing of PMs after bank account verification

### DIFF
--- a/examples/ach/credit_external_bank/micro_deposits_test.go
+++ b/examples/ach/credit_external_bank/micro_deposits_test.go
@@ -81,8 +81,13 @@ func TestMicroDepositExample(t *testing.T) {
 
 	// When we have only one bank account linked, we can avoid checking that the
 	// payment method is for user's bank account and just use the first one.
-	paymentMethods, err := mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
-	require.NoError(t, err)
+	var paymentMethods []moov.PaymentMethod
+	require.Eventually(t, func() bool {
+		paymentMethods, err = mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
+		require.NoError(t, err)
+
+		return len(paymentMethods) > 0
+	}, 10*time.Second, time.Second)
 
 	// We expect to have only one `moov-wallet` payment method on the connected account
 	require.Len(t, paymentMethods, 1)

--- a/examples/ach/debit_bank_account/micro_deposits_test.go
+++ b/examples/ach/debit_bank_account/micro_deposits_test.go
@@ -81,8 +81,13 @@ func TestMicroDepositExample(t *testing.T) {
 
 	// When we have only one bank account linked, we can avoid checking that the
 	// payment method is for user's bank account and just use the first one.
-	paymentMethods, err := mc.ListPaymentMethods(ctx, account.AccountID, moov.WithPaymentMethodType("ach-debit-collect"))
-	require.NoError(t, err)
+	var paymentMethods []moov.PaymentMethod
+	require.Eventually(t, func() bool {
+		paymentMethods, err = mc.ListPaymentMethods(ctx, account.AccountID, moov.WithPaymentMethodType("ach-debit-collect"))
+		require.NoError(t, err)
+
+		return len(paymentMethods) > 0
+	}, 10*time.Second, time.Second)
 
 	// We expect to have only one `ach-debit-collect` payment method as we added
 	// only one bank account


### PR DESCRIPTION
We're looking at adding `x-wait-for: payment-method` to the MD complete endpoint to avoid this need to retry. 

See this failure https://github.com/moovfinancial/moov-go/actions/runs/9597059892/job/26465311023 