### PR TITLE
Update event.data from []byte to json.RawMessage (bug-fix) and support test ping event type

### DIFF
--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -71,6 +71,8 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 		eventData = &event.representativeDeleted
 	case EventTypeRepresentativeUpdated:
 		eventData = &event.representativeUpdated
+	case EventTypeTest:
+		eventData = &event.testPing
 	case EventTypeTransferCreated:
 		eventData = &event.transferCreated
 	case EventTypeTransferUpdated:
@@ -88,10 +90,10 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 }
 
 type Event struct {
-	EventID   string    `json:"eventID"`
-	EventType EventType `json:"type"`
-	CreatedOn time.Time `json:"createdOn"`
-	Data      []byte    `json:"data"`
+	EventID   string          `json:"eventID"`
+	EventType EventType       `json:"type"`
+	CreatedOn time.Time       `json:"createdOn"`
+	Data      json.RawMessage `json:"data"`
 
 	accountCreated           *AccountCreated
 	accountDeleted           *AccountDeleted
@@ -113,6 +115,7 @@ type Event struct {
 	representativeCreated    *RepresentativeCreated
 	representativeDeleted    *RepresentativeDeleted
 	representativeUpdated    *RepresentativeUpdated
+	testPing                 *TestPing
 	transferCreated          *TransferCreated
 	transferUpdated          *TransferUpdated
 	walletTransactionUpdated *WalletTransactionUpdated

--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -281,6 +281,14 @@ func (e Event) RepresentativeUpdated() (*RepresentativeUpdated, error) {
 	return e.representativeUpdated, nil
 }
 
+func (e Event) TestPing() (*TestPing, error) {
+	if e.EventType != EventTypeTest {
+		return nil, newInvalidEventTypeError(EventTypeTest, e.EventType)
+	}
+
+	return e.testPing, nil
+}
+
 func (e Event) TransferCreated() (*TransferCreated, error) {
 	if e.EventType != EventTypeTransferCreated {
 		return nil, newInvalidEventTypeError(EventTypeTransferCreated, e.EventType)

--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -71,7 +71,7 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 		eventData = &event.representativeDeleted
 	case EventTypeRepresentativeUpdated:
 		eventData = &event.representativeUpdated
-	case EventTypeTest:
+	case EventTypeTestPing:
 		eventData = &event.testPing
 	case EventTypeTransferCreated:
 		eventData = &event.transferCreated
@@ -79,6 +79,8 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 		eventData = &event.transferUpdated
 	case EventTypeWalletTransactionUpdated:
 		eventData = &event.walletTransactionUpdated
+	default:
+		return nil, fmt.Errorf("invalid event type: %v", event.EventType)
 	}
 
 	err = json.Unmarshal(event.Data, eventData)
@@ -282,8 +284,8 @@ func (e Event) RepresentativeUpdated() (*RepresentativeUpdated, error) {
 }
 
 func (e Event) TestPing() (*TestPing, error) {
-	if e.EventType != EventTypeTest {
-		return nil, newInvalidEventTypeError(EventTypeTest, e.EventType)
+	if e.EventType != EventTypeTestPing {
+		return nil, newInvalidEventTypeError(EventTypeTestPing, e.EventType)
 	}
 
 	return e.testPing, nil

--- a/pkg/mhooks/event_test.go
+++ b/pkg/mhooks/event_test.go
@@ -21,6 +21,10 @@ func TestParseEvent(t *testing.T) {
 		secret    = "my-webhook-signing-secret"
 		signature = "6231d03752de6963087e6aea1c78a27a0617b6df1c071195f30ed85defe34e02fd0bf3995949fe12dafd747c42de9cfae03b8aafcf69cceba5495f4c7b719d82"
 
+		testPing = TestPing{
+			Ping: true,
+		}
+
 		accountCreated = AccountCreated{
 			AccountID: uuid.NewString(),
 		}
@@ -62,6 +66,10 @@ func TestParseEvent(t *testing.T) {
 		eventType EventType
 		data      any
 	}{
+		{
+			eventType: EventTypeTest,
+			data:      testPing,
+		},
 		{
 			eventType: EventTypeAccountCreated,
 			data:      accountCreated,

--- a/pkg/mhooks/event_test.go
+++ b/pkg/mhooks/event_test.go
@@ -45,6 +45,12 @@ func TestParseEvent(t *testing.T) {
 
 		//nolint:exhaustive
 		switch event.EventType {
+		case EventTypeTest:
+			got, err := event.TestPing()
+			require.NoError(t, err)
+
+			t.Log("Got TestPing webhook")
+			require.Equal(t, testPing, *got)
 		case EventTypeAccountCreated:
 			got, err := event.AccountCreated()
 			require.NoError(t, err)
@@ -57,6 +63,8 @@ func TestParseEvent(t *testing.T) {
 
 			t.Logf("Got TransferCreated webhook with transferID=%v\n", got.TransferID)
 			require.Equal(t, transferCreated, *got)
+		default:
+			require.FailNow(t, "unexpected event type: %v", event.EventType)
 		}
 
 		w.WriteHeader(200)

--- a/pkg/mhooks/event_test.go
+++ b/pkg/mhooks/event_test.go
@@ -45,7 +45,7 @@ func TestParseEvent(t *testing.T) {
 
 		//nolint:exhaustive
 		switch event.EventType {
-		case EventTypeTest:
+		case EventTypeTestPing:
 			got, err := event.TestPing()
 			require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestParseEvent(t *testing.T) {
 		data      any
 	}{
 		{
-			eventType: EventTypeTest,
+			eventType: EventTypeTestPing,
 			data:      testPing,
 		},
 		{

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -29,6 +29,7 @@ const (
 	EventTypeRepresentativeCreated    EventType = "representative.created"
 	EventTypeRepresentativeDeleted    EventType = "representative.deleted"
 	EventTypeRepresentativeUpdated    EventType = "representative.updated"
+	EventTypeTest                     EventType = "event.test"
 	EventTypeTransferCreated          EventType = "transfer.created"
 	EventTypeTransferUpdated          EventType = "transfer.updated"
 	EventTypeWalletTransactionUpdated EventType = "walletTransaction.updated"
@@ -196,6 +197,10 @@ type RepresentativeUpdated struct {
 	RepresentativeID string `json:"representativeID"`
 	// ID of the account
 	AccountID string `json:"accountID"`
+}
+
+type TestPing struct {
+	Ping bool `json:"ping"`
 }
 
 type TransferCreated struct {

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -29,7 +29,7 @@ const (
 	EventTypeRepresentativeCreated    EventType = "representative.created"
 	EventTypeRepresentativeDeleted    EventType = "representative.deleted"
 	EventTypeRepresentativeUpdated    EventType = "representative.updated"
-	EventTypeTest                     EventType = "event.test"
+	EventTypeTestPing                 EventType = "event.test"
 	EventTypeTransferCreated          EventType = "transfer.created"
 	EventTypeTransferUpdated          EventType = "transfer.updated"
 	EventTypeWalletTransactionUpdated EventType = "walletTransaction.updated"


### PR DESCRIPTION
### Changes

#### bug-fix: Update `event.data` field type from `[]byte` to `json.RawMessage`
This reverts @InfernoJJ 's suggestion [here](https://github.com/moovfinancial/moov-go/pull/97#discussion_r1582994946) on using `[]byte` over `json.RawMessage`.

This seemed like an ok change given unit-tests passed, but bug occurs when the `event.data` is not base64 encoded. Calling `ParseEvent` will result in the error `decoding event: json: cannot unmarshal object into Go struct field Event.data of type []uint8`.

The reason this was not caught in unit-tests is because our test code uses `json.NewEncoder(..).Encode(..)` ([link](https://github.com/moovfinancial/moov-go/blob/main/pkg/mhooks/event_test.go#L86)), which will encode nested JSON fields as base64. But in practice, we do not send `event.data` as base64 encoded values.

Updating this back to `json.RawMessage` fixes the issue.


#### Support the payload from our `/webhooks/{webhookID}/ping` endpoint.
Customers will likely start testing webhooks by utlizing the `ping` endpoint, so we should support this as an event type.
This involves adding the `event.test` event type and model to transform `{"ping": true}`

Example request body: 
```json
{"eventID":"cf29a3a8-4c3a-488e-8621-32a87566bb8b","type":"event.test","data":{"ping":true},"createdOn":"2024-06-20T19:30:20Z"}
```
