### PR TITLE
moov: extract "error" from JSON response on 400s

### DIFF
--- a/pkg/moov/http_test.go
+++ b/pkg/moov/http_test.go
@@ -2,13 +2,28 @@ package moov
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPCallResponse(t *testing.T) {
-	t.Run("Error", func(t *testing.T) {
+	t.Run("400", func(t *testing.T) {
+		resp := &httpCallResponse{
+			resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+			},
+			body: []byte(`{"error":"X-Idempotency-Key HTTP header must be a valid UUID"}`),
+		}
+		expected := strings.TrimSpace(`
+error from moov - status: bad_request http.request_id:  http.status_code: 400
+  X-Idempotency-Key HTTP header must be a valid UUID
+`)
+		require.Equal(t, expected, resp.Error())
+	})
+
+	t.Run("409 and 422", func(t *testing.T) {
 		resp := &httpCallResponse{
 			resp: &http.Response{
 				StatusCode: http.StatusUnprocessableEntity,


### PR DESCRIPTION
Adds the content of `"error"` from JSON responses.

```
error from moov - status: bad_request http.request_id:  http.status_code: 400
  X-Idempotency-Key HTTP header must be a valid UUID
```