### PR TITLE
cleanup: remove UUID comments

### DIFF
--- a/pkg/moov/account_models.go
+++ b/pkg/moov/account_models.go
@@ -93,8 +93,7 @@ type AccountCapability struct {
 
 // Account Describes a Moov account.
 type Account struct {
-	Mode Mode `json:"mode,omitempty"`
-	// UUID v4
+	Mode        Mode        `json:"mode,omitempty"`
 	AccountID   string      `json:"accountID,omitempty"`
 	AccountType AccountType `json:"accountType,omitempty"`
 	DisplayName string      `json:"displayName,omitempty"`

--- a/pkg/moov/bank_account_models.go
+++ b/pkg/moov/bank_account_models.go
@@ -54,7 +54,6 @@ type MXRequest struct {
 
 // BankAccountResponse Describes a bank account on a Moov account.
 type BankAccount struct {
-	// UUID v4
 	BankAccountID string `json:"bankAccountID,omitempty"`
 	// Once the bank account is linked, we don't reveal the full bank account number. The fingerprint acts as a way to identify whether two linked bank accounts are the same.
 	Fingerprint           string                  `json:"fingerprint,omitempty"`

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -2,7 +2,6 @@ package moov
 
 // PaymentMethod A method of moving money
 type PaymentMethod struct {
-	// UUID v4
 	PaymentMethodID   string                    `json:"paymentMethodID,omitempty"`
 	PaymentMethodType PaymentMethodType         `json:"paymentMethodType,omitempty"`
 	Wallet            *WalletPaymentMethod      `json:"wallet,omitempty"`
@@ -13,7 +12,6 @@ type PaymentMethod struct {
 
 // BasicPaymentMethod struct for BasicPaymentMethod
 type BasicPaymentMethod struct {
-	// UUID v4
 	PaymentMethodID   string            `json:"paymentMethodID,omitempty"`
 	PaymentMethodType PaymentMethodType `json:"paymentMethodType,omitempty"`
 }
@@ -37,7 +35,6 @@ const (
 
 // WalletPaymentMethod A Moov wallet to store funds for transfers.
 type WalletPaymentMethod struct {
-	// UUID v4
 	WalletID string `json:"walletID,omitempty"`
 }
 
@@ -45,7 +42,6 @@ type BankAccountPaymentMethod BankAccount
 
 // Card Describes a card on a Moov account.
 type CardPaymentMethod struct {
-	// UUID v4
 	CardID string `json:"cardID,omitempty"`
 	// Uniquely identifies a linked payment card or token. For Apple Pay, the fingerprint is based on the tokenized card number and may vary based on the user's device. This field can be used to identify specific payment methods across multiple accounts on your platform.
 	Fingerprint        string            `json:"fingerprint,omitempty"`

--- a/pkg/moov/representative_model.go
+++ b/pkg/moov/representative_model.go
@@ -4,7 +4,6 @@ import "time"
 
 // Representative Describes a business representative.
 type Representative struct {
-	// UUID v4
 	RepresentativeID string `json:"representativeID,omitempty"`
 	Name             Name   `json:"name,omitempty"`
 	Phone            *Phone `json:"phone,omitempty"`

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -16,9 +16,7 @@ type CreateTransfer struct {
 
 // CreateTransfer_Source Where funds for a transfer originate. For the source, you must include either a `paymentMethodID` or a `transferID`. A `transferID` is used to create a [transfer group](https://docs.moov.io/guides/money-movement/transfer-groups/), associating the new transfer with a parent transfer.
 type CreateTransfer_Source struct {
-	// UUID v4
-	TransferID string `json:"transferID,omitempty"`
-	// UUID v4
+	TransferID      string                            `json:"transferID,omitempty"`
 	PaymentMethodID string                            `json:"paymentMethodID,omitempty"`
 	CardDetails     *CreateTransfer_CardDetailsSource `json:"cardDetails,omitempty"`
 	AchDetails      *CreateTransfer_AchDetailsSource  `json:"achDetails,omitempty"`
@@ -43,7 +41,6 @@ type CreateTransfer_AchDetailsSource struct {
 
 // CreateTransfer_Destination The final stage of a transfer and the ultimate recipient of the funds.
 type CreateTransfer_Destination struct {
-	// UUID v4
 	PaymentMethodID string                                 `json:"paymentMethodID"`
 	CardDetails     *CreateTransfer_CardDetailsDestination `json:"cardDetails,omitempty"`
 	AchDetails      *CreateTransfer_AchDetailsBase         `json:"achDetails,omitempty"`
@@ -84,7 +81,6 @@ type TransferStarted struct {
 
 // Transfer struct for Transfer
 type Transfer struct {
-	// UUID v4
 	TransferID    string         `json:"transferID,omitempty"`
 	CreatedOn     time.Time      `json:"createdOn,omitempty"`
 	CompletedOn   *time.Time     `json:"completedOn,omitempty"`
@@ -155,7 +151,6 @@ type MoovFeeDetails struct {
 
 // Refund Details of a card refund.
 type Refund struct {
-	// UUID v4
 	RefundID  string       `json:"refundID,omitempty"`
 	CreatedOn time.Time    `json:"createdOn,omitempty"`
 	UpdatedOn time.Time    `json:"updatedOn,omitempty"`
@@ -179,7 +174,6 @@ type RefundCardDetails struct {
 
 // GetDispute Details of a card dispute.
 type GetDispute struct {
-	// UUID v4
 	DisputeID string    `json:"disputeID,omitempty"`
 	CreatedOn time.Time `json:"createdOn,omitempty"`
 	Amount    Amount    `json:"amount,omitempty"`
@@ -187,7 +181,6 @@ type GetDispute struct {
 
 // TransferSource struct for TransferSource
 type TransferSource struct {
-	// UUID v4
 	PaymentMethodID   string                    `json:"paymentMethodID,omitempty"`
 	PaymentMethodType PaymentMethodType         `json:"paymentMethodType,omitempty"`
 	Account           TransferAccount           `json:"account,omitempty"`
@@ -197,8 +190,7 @@ type TransferSource struct {
 	ApplePay          *ApplePayPaymentMethod    `json:"applePay,omitempty"`
 	AchDetails        *AchDetailsSource         `json:"achDetails,omitempty"`
 	CardDetails       *CardDetails              `json:"cardDetails,omitempty"`
-	// UUID v4
-	TransferID string `json:"transferID,omitempty"`
+	TransferID        string                    `json:"transferID,omitempty"`
 }
 
 // TransferAccount struct for TransferAccount
@@ -238,7 +230,6 @@ type AchException struct {
 
 // TransferDestination struct for TransferDestination
 type TransferDestination struct {
-	// UUID v4
 	PaymentMethodID   string                    `json:"paymentMethodID,omitempty"`
 	PaymentMethodType PaymentMethodType         `json:"paymentMethodType,omitempty"`
 	Account           TransferAccount           `json:"account,omitempty"`
@@ -323,9 +314,7 @@ type CreateTransferOptions struct {
 
 // CreateTransferOptionsTarget struct for CreateTransferOptionsTarget
 type CreateTransferOptionsTarget struct {
-	// UUID v4
-	AccountID string `json:"accountID,omitempty"`
-	// UUID v4
+	AccountID       string `json:"accountID,omitempty"`
 	PaymentMethodID string `json:"paymentMethodID,omitempty"`
 }
 


### PR DESCRIPTION
I was going to rename `UUID V4` to just `UUID` to coincide with changes [here](https://github.com/moovfinancial/platform-api/pull/861) -- but the UUID comments aren't consistent across fields and it's pretty obvious the fields are IDs