### PR TITLE
define card transaction status values

### DIFF
--- a/pkg/moov/cards.go
+++ b/pkg/moov/cards.go
@@ -51,18 +51,41 @@ type CardAccountUpdater struct {
 }
 
 type CardDetails struct {
-	Status                   string     `json:"status,omitempty"`
-	FailureCode              string     `json:"failureCode,omitempty"`
-	DynamicDescriptor        string     `json:"dynamicDescriptor,omitempty"`
-	TransactionSource        string     `json:"transactionSource,omitempty"`
-	InterchangeQualification string     `json:"interchangeQualification,omitempty"`
-	InitiatedOn              *time.Time `json:"initiatedOn,omitempty"`
-	ConfirmedOn              *time.Time `json:"confirmedOn,omitempty"`
-	SettledOn                *time.Time `json:"settledOn,omitempty"`
-	FailedOn                 *time.Time `json:"failedOn,omitempty"`
-	CanceledOn               *time.Time `json:"canceledOn,omitempty"`
-	CompletedOn              *time.Time `json:"completedOn,omitempty"`
+	Status                   CardTransactionStatus `json:"status,omitempty"`
+	FailureCode              string                `json:"failureCode,omitempty"`
+	DynamicDescriptor        string                `json:"dynamicDescriptor,omitempty"`
+	TransactionSource        string                `json:"transactionSource,omitempty"`
+	InterchangeQualification string                `json:"interchangeQualification,omitempty"`
+	InitiatedOn              *time.Time            `json:"initiatedOn,omitempty"`
+	ConfirmedOn              *time.Time            `json:"confirmedOn,omitempty"`
+	SettledOn                *time.Time            `json:"settledOn,omitempty"`
+	FailedOn                 *time.Time            `json:"failedOn,omitempty"`
+	CanceledOn               *time.Time            `json:"canceledOn,omitempty"`
+	CompletedOn              *time.Time            `json:"completedOn,omitempty"`
 }
+
+// CardTransactionStatus represents the status of a card transaction within a Transfer
+type CardTransactionStatus string
+
+const (
+	// Transaction has been initiated
+	CardTransactionStatus_Initiated CardTransactionStatus = "initiated"
+
+	// Transaction has been authorized by the card network
+	CardTransactionStatus_Confirmed CardTransactionStatus = "confirmed"
+
+	// Transaction settled with issuer; Moov wallet will be credited by 1 PM ET on a banking day, or the next banking day if it is a weekend or a holiday
+	CardTransactionStatus_Settled CardTransactionStatus = "settled"
+
+	// Funds have been credited to the merchant Moov wallet
+	CardTransactionStatus_Completed CardTransactionStatus = "completed"
+
+	// Transaction was successfully cancelled and authorization has been reversed
+	CardTransactionStatus_Canceled CardTransactionStatus = "canceled"
+
+	// Transaction failed; specific failure reason will be in cardDetails.failureCode
+	CardTransactionStatus_Failed CardTransactionStatus = "failed"
+)
 
 type CreateCard struct {
 	CardNumber        string     `json:"cardNumber,omitempty"`


### PR DESCRIPTION
Added the enum from our API docs and used the descriptions from our [card acceptance guide](https://docs.moov.io/guides/money-movement/accept-payments/card-acceptance/#card-status).