### PR TITLE
transfers: add salesTaxAmount to Transfer model

### DIFF
--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -121,6 +121,9 @@ type Transfer struct {
 	Disputes []GetDispute `json:"disputes,omitempty"`
 	// A list of cancellations for a transfer.
 	Cancellations []Cancellation `json:"cancellations,omitempty"`
+
+	// Optional sales tax amount. `transfer.amount.value` should be inclusive of any sales tax and represents the total amount charged.
+	SalesTaxAmount *Amount `json:"salesTaxAmount,omitempty"`
 }
 
 // Amount A representation of money containing an integer value and its currency.

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -122,7 +122,7 @@ type Transfer struct {
 	// A list of cancellations for a transfer.
 	Cancellations []Cancellation `json:"cancellations,omitempty"`
 
-	// Optional sales tax amount. `transfer.amount.value` should be inclusive of any sales tax and represents the total amount charged.
+	// Optional sales tax amount. Transfer.Amount.Value should be inclusive of any sales tax and represents the total amount charged.
 	SalesTaxAmount *Amount `json:"salesTaxAmount,omitempty"`
 }
 


### PR DESCRIPTION
Looks like this was missed in #186 given it was only added to the `CreateTransfer` model -- but it's set on the `Transfer` model too