### PR TITLE
feat: allow to configure moov url scheme via configurators

### DIFF
--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	moovgo "github.com/moovfinancial/moov-go"
@@ -25,12 +24,7 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 		return nil, err
 	}
 
-	moovUrlScheme, ok := os.LookupEnv("MOOV_URL_SCHEME")
-	if !ok || moovUrlScheme == "" {
-		moovUrlScheme = "https"
-	}
-
-	url := fmt.Sprintf("%s://%s%s", moovUrlScheme, c.Credentials.Host, call.path)
+	url := fmt.Sprintf("%s://%s%s", c.moovURLScheme, c.Credentials.Host, call.path)
 
 	req, err := http.NewRequestWithContext(ctx, call.method, url, call.body)
 	if err != nil {


### PR DESCRIPTION
In local testing environment I don't want to use environment variables for scheme as the rest of the parameters can be configured during client initialization using configurators. With this PR we make it a bit more consistent.

Now you can:

```
// This will use ENV var or default (https)
client, _ := moov.NewClient()

// This will start with ENV var, then override with explicit value
client, _ := moov.NewClient(moov.WithMoovURLScheme("http"))
```