### PR TITLE
feat: add terminal application linking, version code creation, etc.

### DIFF
--- a/pkg/moov/account_terminal_application_api.go
+++ b/pkg/moov/account_terminal_application_api.go
@@ -1,0 +1,63 @@
+package moov
+
+import (
+	"context"
+	"net/http"
+)
+
+// CreateTerminalApplication creates a new terminal application.
+func (c Client) LinkAccountTerminalApplication(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplication, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathAccountTerminalApplications, accountID),
+		AcceptJson(),
+		JsonBody(LinkAccountTerminalApplicationRequest{
+			TerminalApplicationID: terminalApplicationID,
+		}))
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.Status() {
+	case StatusCompleted:
+		a, err := UnmarshalObjectResponse[AccountTerminalApplication](resp)
+		return a, err
+	default:
+		return nil, resp
+	}
+}
+
+// GetTerminalApplication returns a terminal application based on terminalApplicationID.
+func (c Client) GetAccountTerminalApplication(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplication, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathAccountTerminalApplication, accountID, terminalApplicationID),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[AccountTerminalApplication](resp)
+}
+
+// ListTerminalApplications returns a list of terminalApplications.
+func (c Client) ListAccountTerminalApplications(ctx context.Context, accountID string) ([]AccountTerminalApplication, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathAccountTerminalApplications, accountID),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedListOrError[AccountTerminalApplication](resp)
+}
+
+// GetTerminalApplication returns a terminal application based on terminalApplicationID.
+func (c Client) GetAccountTerminalApplicationConfiguration(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplicationConfiguration, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathAccountTerminalApplicationConfiguration, accountID, terminalApplicationID),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[AccountTerminalApplicationConfiguration](resp)
+}

--- a/pkg/moov/account_terminal_application_api.go
+++ b/pkg/moov/account_terminal_application_api.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-// CreateTerminalApplication creates a new terminal application.
+// LinkAccountTerminalApplication links an account to a terminal application.
 func (c Client) LinkAccountTerminalApplication(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplication, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathAccountTerminalApplications, accountID),
@@ -17,16 +17,10 @@ func (c Client) LinkAccountTerminalApplication(ctx context.Context, accountID, t
 		return nil, err
 	}
 
-	switch resp.Status() {
-	case StatusCompleted:
-		a, err := UnmarshalObjectResponse[AccountTerminalApplication](resp)
-		return a, err
-	default:
-		return nil, resp
-	}
+	return CompletedObjectOrError[AccountTerminalApplication](resp)
 }
 
-// GetTerminalApplication returns a terminal application based on terminalApplicationID.
+// GetAccountTerminalApplication gets an account-terminal application link.
 func (c Client) GetAccountTerminalApplication(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplication, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodGet, pathAccountTerminalApplication, accountID, terminalApplicationID),
@@ -38,7 +32,7 @@ func (c Client) GetAccountTerminalApplication(ctx context.Context, accountID, te
 	return CompletedObjectOrError[AccountTerminalApplication](resp)
 }
 
-// ListTerminalApplications returns a list of terminalApplications.
+// ListAccountTerminalApplications lists account-terminal application links for an account.
 func (c Client) ListAccountTerminalApplications(ctx context.Context, accountID string) ([]AccountTerminalApplication, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodGet, pathAccountTerminalApplications, accountID),
@@ -50,7 +44,7 @@ func (c Client) ListAccountTerminalApplications(ctx context.Context, accountID s
 	return CompletedListOrError[AccountTerminalApplication](resp)
 }
 
-// GetTerminalApplication returns a terminal application based on terminalApplicationID.
+// GetAccountTerminalApplicationConfiguration gets configuration for a linked terminal application.
 func (c Client) GetAccountTerminalApplicationConfiguration(ctx context.Context, accountID, terminalApplicationID string) (*AccountTerminalApplicationConfiguration, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodGet, pathAccountTerminalApplicationConfiguration, accountID, terminalApplicationID),

--- a/pkg/moov/account_terminal_application_models.go
+++ b/pkg/moov/account_terminal_application_models.go
@@ -1,0 +1,14 @@
+package moov
+
+type AccountTerminalApplication struct {
+	AccountID             string `json:"accountID"`
+	TerminalApplicationID string `json:"terminalApplicationID"`
+}
+
+type LinkAccountTerminalApplicationRequest struct {
+	TerminalApplicationID string `json:"terminalApplicationID"`
+}
+
+type AccountTerminalApplicationConfiguration struct {
+	Configuration string `json:"configuration"`
+}

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -88,6 +88,11 @@ const (
 	pathEndToEndPublicKey = "/end-to-end-keys"
 	pathEndToEndTokenTest = "/debug/end-to-end-token" //nolint:gosec
 
-	pathTerminalApplications = "/terminal-applications"
-	pathTerminalApplication  = "/terminal-applications/%s"
+	pathTerminalApplications        = "/terminal-applications"
+	pathTerminalApplication         = "/terminal-applications/%s"
+	pathTerminalApplicationVersions = "/terminal-applications/%s/versions"
+
+	pathAccountTerminalApplication              = "/accounts/%s/terminal-applications/%s"
+	pathAccountTerminalApplications             = "/accounts/%s/terminal-applications"
+	pathAccountTerminalApplicationConfiguration = "/accounts/%s/terminal-applications/%s/configuration"
 )

--- a/pkg/moov/terminal_application_api.go
+++ b/pkg/moov/terminal_application_api.go
@@ -6,25 +6,21 @@ import (
 )
 
 // CreateTerminalApplication creates a new terminal application.
-func (c Client) CreateTerminalApplication(ctx context.Context, terminalApplication TerminalApplicationRequest) (*TerminalApplication, *TerminalApplication, error) {
+func (c Client) CreateTerminalApplication(ctx context.Context, terminalApplication TerminalApplicationRequest) (*TerminalApplication, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathTerminalApplications),
 		AcceptJson(),
-		WaitFor("connection"),
 		JsonBody(terminalApplication))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	switch resp.Status() {
 	case StatusCompleted:
 		a, err := UnmarshalObjectResponse[TerminalApplication](resp)
-		return a, nil, err
-	case StatusStarted:
-		a, err := UnmarshalObjectResponse[TerminalApplication](resp)
-		return nil, a, err
+		return a, err
 	default:
-		return nil, nil, resp
+		return nil, resp
 	}
 }
 
@@ -60,4 +56,22 @@ func (c Client) DeleteTerminalApplication(ctx context.Context, terminalApplicati
 	}
 
 	return CompletedNilOrError(resp)
+}
+
+func (c Client) CreateTerminalApplicationVersion(ctx context.Context, terminalApplicationID string, version TerminalApplicationVersion) (*TerminalApplicationVersion, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathTerminalApplicationVersions, terminalApplicationID),
+		AcceptJson(),
+		JsonBody(version))
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.Status() {
+	case StatusCompleted:
+		a, err := UnmarshalObjectResponse[TerminalApplicationVersion](resp)
+		return a, err
+	default:
+		return nil, resp
+	}
 }

--- a/pkg/moov/terminal_application_api.go
+++ b/pkg/moov/terminal_application_api.go
@@ -58,11 +58,13 @@ func (c Client) DeleteTerminalApplication(ctx context.Context, terminalApplicati
 	return CompletedNilOrError(resp)
 }
 
-func (c Client) CreateTerminalApplicationVersion(ctx context.Context, terminalApplicationID string, version TerminalApplicationVersion) (*TerminalApplicationVersion, error) {
+func (c Client) CreateTerminalApplicationVersion(ctx context.Context, terminalApplicationID, version string) (*TerminalApplicationVersion, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathTerminalApplicationVersions, terminalApplicationID),
 		AcceptJson(),
-		JsonBody(version))
+		JsonBody(TerminalApplicationVersion{
+			Version: version,
+		}))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/moov/terminal_application_api.go
+++ b/pkg/moov/terminal_application_api.go
@@ -15,13 +15,7 @@ func (c Client) CreateTerminalApplication(ctx context.Context, terminalApplicati
 		return nil, err
 	}
 
-	switch resp.Status() {
-	case StatusCompleted:
-		a, err := UnmarshalObjectResponse[TerminalApplication](resp)
-		return a, err
-	default:
-		return nil, resp
-	}
+	return CompletedObjectOrError[TerminalApplication](resp)
 }
 
 // GetTerminalApplication returns a terminal application based on terminalApplicationID.
@@ -58,6 +52,8 @@ func (c Client) DeleteTerminalApplication(ctx context.Context, terminalApplicati
 	return CompletedNilOrError(resp)
 }
 
+// CreateTerminalApplicationVersion registers a new version for a terminal
+// application. Value of Version code should be used for Android applications.
 func (c Client) CreateTerminalApplicationVersion(ctx context.Context, terminalApplicationID, version string) (*TerminalApplicationVersion, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathTerminalApplicationVersions, terminalApplicationID),
@@ -69,11 +65,5 @@ func (c Client) CreateTerminalApplicationVersion(ctx context.Context, terminalAp
 		return nil, err
 	}
 
-	switch resp.Status() {
-	case StatusCompleted:
-		a, err := UnmarshalObjectResponse[TerminalApplicationVersion](resp)
-		return a, err
-	default:
-		return nil, resp
-	}
+	return CompletedObjectOrError[TerminalApplicationVersion](resp)
 }

--- a/pkg/moov/terminal_application_models.go
+++ b/pkg/moov/terminal_application_models.go
@@ -1,5 +1,7 @@
 package moov
 
+import "time"
+
 type TerminalApplicationStatus string
 
 // List of TerminalApplicationStatus
@@ -26,6 +28,8 @@ type TerminalApplication struct {
 	PackageName           string                      `json:"packageName,omitempty"`
 	Sha256Digest          string                      `json:"sha256Digest,omitempty"`
 	VersionCode           string                      `json:"versionCode,omitempty"`
+	CreatedOn             time.Time                   `json:"createdOn"`
+	UpdatedOn             time.Time                   `json:"updatedOn"`
 }
 
 type TerminalApplicationRequest struct {

--- a/pkg/moov/terminal_application_models.go
+++ b/pkg/moov/terminal_application_models.go
@@ -39,3 +39,7 @@ type TerminalApplicationRequest struct {
 	// The app version of the terminal application. Required if platform is `android`.
 	VersionCode string `json:"versionCode,omitempty"`
 }
+
+type TerminalApplicationVersion struct {
+	Version string `json:"version"`
+}


### PR DESCRIPTION
With this PR we can:
* Added methods for terminal applications (create, get, list, link with merchant account, get terminal config, register new terminal application version)
* BREAKING CHANGE: `CreateTerminalApplication` returns two values, instead of three

P.S. JH is notified about breaking change and they are ok with it.