### PR TITLE
COR-3762 - moov-go updates for granular capabilities

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-faker/faker/v4 v4.6.0 h1:6aOPzNptRiDwD14HuAnEtlTa+D1IfFuEHO8+vEFwjTs=
-github.com/go-faker/faker/v4 v4.6.0/go.mod h1:ZmrHuVtTTm2Em9e0Du6CJ9CADaLEzGXW62z1YqFH0m0=
 github.com/go-faker/faker/v4 v4.6.1 h1:xUyVpAjEtB04l6XFY0V/29oR332rOSPWV4lU8RwDt4k=
 github.com/go-faker/faker/v4 v4.6.1/go.mod h1:arSdxNCSt7mOhdk8tEolvHeIJ7eX4OX80wXjKKvkKBY=
 github.com/go-jose/go-jose/v4 v4.1.0 h1:cYSYxd3pw5zd2FSXk2vGdn9igQU2PS8MuxrCOCl0FdY=

--- a/pkg/moov/capabilities_api.go
+++ b/pkg/moov/capabilities_api.go
@@ -5,6 +5,70 @@ import (
 	"net/http"
 )
 
+type CapabilityClient[T any, V any] struct {
+	Version Version
+}
+
+// Request adds one or more new capability to the given account
+func (cc CapabilityClient[T, V]) Request(ctx context.Context, client Client, accountID string, requested T) ([]V, error) {
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathCapabilities, accountID),
+		MoovVersion(cc.Version),
+		AcceptJson(),
+		JsonBody(requested))
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.Status() {
+	case StatusCompleted:
+		return CompletedListOrError[V](resp)
+	default:
+		return nil, resp
+	}
+}
+
+// List returns the capabilities for the given account and version
+func (cc CapabilityClient[T, V]) List(ctx context.Context, client Client, accountID string) ([]V, error) {
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathCapabilities, accountID),
+		MoovVersion(cc.Version),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedListOrError[V](resp)
+}
+
+// Get returns a given capability for a given account
+func (cc CapabilityClient[T, V]) Get(ctx context.Context, client Client, accountID string, capability CapabilityName) (*V, error) {
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathCapability, accountID, capability),
+		MoovVersion(cc.Version),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[V](resp)
+}
+
+// Disable disables a specific capability for a given account
+func (cc CapabilityClient[T, V]) Disable(ctx context.Context, client Client, accountID string, capability CapabilityName) error {
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodDelete, pathCapability, accountID, capability),
+		MoovVersion(cc.Version))
+	if err != nil {
+		return err
+	}
+
+	return CompletedNilOrError(resp)
+}
+
+// Legacy
+
+// Use only for Preversioned API calls. Use mvxxxx.Capabilities.Request(...) instead.
 // RequestCapabilities adds a new capability for the given account
 func (c Client) RequestCapabilities(ctx context.Context, accountID string, capabilities []CapabilityName) ([]Capability, error) {
 	resp, err := c.CallHttp(ctx,
@@ -25,6 +89,7 @@ func (c Client) RequestCapabilities(ctx context.Context, accountID string, capab
 	}
 }
 
+// Use only for Preversioned API calls. Use mvxxxx.Capabilities.List(...) instead.
 // ListCapabilities returns the capabilities for the given account
 func (c Client) ListCapabilities(ctx context.Context, accountID string) ([]Capability, error) {
 	resp, err := c.CallHttp(ctx,
@@ -37,6 +102,7 @@ func (c Client) ListCapabilities(ctx context.Context, accountID string) ([]Capab
 	return CompletedListOrError[Capability](resp)
 }
 
+// Use only for Preversioned API calls. Use mvxxxx.Capabilities.Get(...) instead.
 // GetCapability returns a given capability for a given account
 func (c Client) GetCapability(ctx context.Context, accountID string, capability CapabilityName) (*Capability, error) {
 	resp, err := c.CallHttp(ctx,
@@ -49,6 +115,7 @@ func (c Client) GetCapability(ctx context.Context, accountID string, capability 
 	return CompletedObjectOrError[Capability](resp)
 }
 
+// Use only for Preversioned API calls. Use mvxxxx.Capabilities.Disable(...) instead.
 // DisableCapability disables a specific capability
 func (c Client) DisableCapability(ctx context.Context, accountID string, capability CapabilityName) error {
 	resp, err := c.CallHttp(ctx, Endpoint(http.MethodDelete, pathCapability, accountID, capability))

--- a/pkg/moov/capabilities_models.go
+++ b/pkg/moov/capabilities_models.go
@@ -17,6 +17,26 @@ const (
 	CapabilityName_SendFunds        CapabilityName = "send-funds"
 	CapabilityName_Transfers        CapabilityName = "transfers"
 	CapabilityName_Wallet           CapabilityName = "wallet"
+
+	// Granular Capability Names Platform
+	CapabilityName_PlatformProductionApp   CapabilityName = "platform.production-app"
+	CapabilityName_PlatformWalletTransfers CapabilityName = "platform.wallet-transfers"
+
+	// Granular Capability Names Wallet
+	Capability_NameWalletBalance CapabilityName = "wallet.balance"
+
+	// Granular Capability Names Collect Funds
+	CapabilityName_CollectFundsACH          CapabilityName = "collect-funds.ach"
+	CapabilityName_CollectFundsCardPayments CapabilityName = "collect-funds.card-payments"
+
+	// Granular Capability Names Money Transfer
+	CapabilityName_MoneyTransferPullFromCard CapabilityName = "money-transfer.pull-from-card"
+	CapabilityName_MoneyTransferPushToCard   CapabilityName = "money-transfer.push-to-card"
+
+	// Granular Capability Names Send Funds
+	CapabilityName_SendFundsACH        CapabilityName = "send-funds.ach"
+	CapabilityName_SendFundsRTP        CapabilityName = "send-funds.rtp"
+	CapabilityName_SendFundsPushToCard CapabilityName = "send-funds.push-to-card"
 )
 
 // Capability Describes an action or set of actions that an account is permitted to perform.

--- a/pkg/moov/capabilities_test.go
+++ b/pkg/moov/capabilities_test.go
@@ -71,11 +71,25 @@ func Test_Capabilities_V2507(t *testing.T) {
 		},
 	}
 
+	private := mv2507.RequestedCapabilities{
+		Capabilities: []moov.CapabilityName{
+			moov.CapabilityName_PlatformProductionApp,
+			moov.CapabilityName_PlatformWalletTransfers,
+		},
+	}
+
 	t.Run("requested", func(t *testing.T) {
-		requested, err := mv2507.Capabilities.Request(BgCtx(), *mc, account.AccountID, requested)
+		resp, err := mv2507.Capabilities.Request(BgCtx(), *mc, account.AccountID, requested)
 
 		NoResponseError(t, err)
-		require.NotEmpty(t, requested)
+		require.NotEmpty(t, resp)
+	})
+
+	t.Run("requested private", func(t *testing.T) {
+		resp, err := mv2507.Capabilities.Request(BgCtx(), *mc, account.AccountID, private)
+
+		require.Error(t, err)
+		require.Nil(t, resp)
 	})
 
 	t.Run("list", func(t *testing.T) {

--- a/pkg/moov/capabilities_test.go
+++ b/pkg/moov/capabilities_test.go
@@ -60,8 +60,6 @@ func Test_Capabilities_V2507(t *testing.T) {
 
 	requested := mv2507.RequestedCapabilities{
 		Capabilities: []moov.CapabilityName{
-			moov.CapabilityName_PlatformProductionApp,
-			moov.CapabilityName_PlatformWalletTransfers,
 			moov.Capability_NameWalletBalance,
 			moov.CapabilityName_CollectFundsACH,
 			moov.CapabilityName_CollectFundsCardPayments,

--- a/pkg/moov/capabilities_test.go
+++ b/pkg/moov/capabilities_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2507"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,49 @@ func Test_Capabilities(t *testing.T) {
 
 	t.Run("disable", func(t *testing.T) {
 		err := mc.DisableCapability(BgCtx(), account.AccountID, moov.CapabilityName_Transfers)
+		NoResponseError(t, err)
+	})
+}
+
+func Test_Capabilities_V2507(t *testing.T) {
+	mc := NewTestClient(t)
+
+	account := CreateTemporaryTestAccount(t, mc, createTestBusinessAccount())
+
+	requested := mv2507.RequestedCapabilities{
+		Capabilities: []moov.CapabilityName{
+			moov.CapabilityName_1099,
+			moov.CapabilityName_CollectFunds,
+			moov.CapabilityName_SendFunds,
+			moov.CapabilityName_Transfers,
+			moov.CapabilityName_Wallet,
+		},
+	}
+
+	t.Run("requested", func(t *testing.T) {
+		requested, err := mv2507.Capabilities.Request(BgCtx(), *mc, account.AccountID, requested)
+
+		NoResponseError(t, err)
+		require.NotEmpty(t, requested)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		requested, err := mv2507.Capabilities.List(BgCtx(), *mc, account.AccountID)
+
+		NoResponseError(t, err)
+		require.NotEmpty(t, requested)
+	})
+
+	t.Run("get", func(t *testing.T) {
+		cap, err := mv2507.Capabilities.Get(BgCtx(), *mc, account.AccountID, moov.CapabilityName_Transfers)
+
+		NoResponseError(t, err)
+		require.NotNil(t, cap)
+	})
+
+	t.Run("disable", func(t *testing.T) {
+		err := mv2507.Capabilities.Disable(BgCtx(), *mc, account.AccountID, moov.CapabilityName_Transfers)
+
 		NoResponseError(t, err)
 	})
 }

--- a/pkg/moov/capabilities_test.go
+++ b/pkg/moov/capabilities_test.go
@@ -42,6 +42,15 @@ func Test_Capabilities(t *testing.T) {
 		err := mc.DisableCapability(BgCtx(), account.AccountID, moov.CapabilityName_Transfers)
 		NoResponseError(t, err)
 	})
+
+	t.Run("cannot request granular capabilities", func(t *testing.T) {
+		requested, err := mc.RequestCapabilities(BgCtx(), account.AccountID, []moov.CapabilityName{
+			moov.CapabilityName_CollectFundsACH,
+		})
+
+		require.Error(t, err)
+		require.Nil(t, requested)
+	})
 }
 
 func Test_Capabilities_V2507(t *testing.T) {
@@ -51,11 +60,16 @@ func Test_Capabilities_V2507(t *testing.T) {
 
 	requested := mv2507.RequestedCapabilities{
 		Capabilities: []moov.CapabilityName{
-			moov.CapabilityName_1099,
-			moov.CapabilityName_CollectFunds,
-			moov.CapabilityName_SendFunds,
-			moov.CapabilityName_Transfers,
-			moov.CapabilityName_Wallet,
+			moov.CapabilityName_PlatformProductionApp,
+			moov.CapabilityName_PlatformWalletTransfers,
+			moov.Capability_NameWalletBalance,
+			moov.CapabilityName_CollectFundsACH,
+			moov.CapabilityName_CollectFundsCardPayments,
+			moov.CapabilityName_MoneyTransferPullFromCard,
+			moov.CapabilityName_MoneyTransferPushToCard,
+			moov.CapabilityName_SendFundsACH,
+			moov.CapabilityName_SendFundsRTP,
+			moov.CapabilityName_SendFundsPushToCard,
 		},
 	}
 

--- a/pkg/mv2507/capability_models.go
+++ b/pkg/mv2507/capability_models.go
@@ -1,0 +1,9 @@
+package mv2507
+
+import "github.com/moovfinancial/moov-go/pkg/moov"
+
+var Capabilities = moov.CapabilityClient[RequestedCapabilities, moov.Capability]{Version: moov.Version2025_07}
+
+type RequestedCapabilities struct {
+	Capabilities []moov.CapabilityName `json:"capabilities"`
+}

--- a/pkg/mv2507/underwriting_models.go
+++ b/pkg/mv2507/underwriting_models.go
@@ -24,7 +24,7 @@ type UnderwritingResp struct {
 	CardVolumeDistribution          moov.CardVolumeDistribution `json:"cardVolumeDistribution"`
 	Fulfillment                     moov.Fulfillment            `json:"fulfillment"`
 
-	//V2507
+	// V2507
 	GeographicReach           *GeographicReach           `json:"geographicReach,omitempty"`
 	BusinessPresence          *BusinessPresence          `json:"businessPresence,omitempty"`
 	PendingLitigation         *PendingLitigation         `json:"pendingLitigation,omitempty"`
@@ -123,38 +123,44 @@ type CardPaymentFulfillment struct {
 
 type FulfillmentMethod string
 
-const FulfillmentMethodBillOrDebtPayment FulfillmentMethod = "bill-or-debt-payment"
-const FulfillmentMethodDigitalContent FulfillmentMethod = "digital-content"
-const FulfillmentMethodDonation FulfillmentMethod = "donation"
-const FulfillmentMethodInPersonService FulfillmentMethod = "in-person-service"
-const FulfillmentMethodLocalPickupOrDelivery FulfillmentMethod = "local-pickup-or-delivery"
-const FulfillmentMethodOther FulfillmentMethod = "other"
-const FulfillmentMethodRemoteService FulfillmentMethod = "remote-service"
-const FulfillmentMethodShippedPhysicalGoods FulfillmentMethod = "shipped-physical-goods"
-const FulfillmentMethodSubscriptionOrMembership FulfillmentMethod = "subscription-or-membership"
+const (
+	FulfillmentMethodBillOrDebtPayment        FulfillmentMethod = "bill-or-debt-payment"
+	FulfillmentMethodDigitalContent           FulfillmentMethod = "digital-content"
+	FulfillmentMethodDonation                 FulfillmentMethod = "donation"
+	FulfillmentMethodInPersonService          FulfillmentMethod = "in-person-service"
+	FulfillmentMethodLocalPickupOrDelivery    FulfillmentMethod = "local-pickup-or-delivery"
+	FulfillmentMethodOther                    FulfillmentMethod = "other"
+	FulfillmentMethodRemoteService            FulfillmentMethod = "remote-service"
+	FulfillmentMethodShippedPhysicalGoods     FulfillmentMethod = "shipped-physical-goods"
+	FulfillmentMethodSubscriptionOrMembership FulfillmentMethod = "subscription-or-membership"
+)
 
 type FulfillmentTimeframe string
 
-const FulfillmentTimeframeImmediate FulfillmentTimeframe = "immediate"
-const FulfillmentTimeframeOther FulfillmentTimeframe = "other"
-const FulfillmentTimeframeOver30Days FulfillmentTimeframe = "over-30-days"
-const FulfillmentTimeframePreOrder FulfillmentTimeframe = "pre-order"
-const FulfillmentTimeframeRecurringSchedule FulfillmentTimeframe = "recurring-schedule"
-const FulfillmentTimeframeScheduledEvent FulfillmentTimeframe = "scheduled-event"
-const FulfillmentTimeframeWithin30Days FulfillmentTimeframe = "within-30-days"
-const FulfillmentTimeframeWithin7Days FulfillmentTimeframe = "within-7-days"
+const (
+	FulfillmentTimeframeImmediate         FulfillmentTimeframe = "immediate"
+	FulfillmentTimeframeOther             FulfillmentTimeframe = "other"
+	FulfillmentTimeframeOver30Days        FulfillmentTimeframe = "over-30-days"
+	FulfillmentTimeframePreOrder          FulfillmentTimeframe = "pre-order"
+	FulfillmentTimeframeRecurringSchedule FulfillmentTimeframe = "recurring-schedule"
+	FulfillmentTimeframeScheduledEvent    FulfillmentTimeframe = "scheduled-event"
+	FulfillmentTimeframeWithin30Days      FulfillmentTimeframe = "within-30-days"
+	FulfillmentTimeframeWithin7Days       FulfillmentTimeframe = "within-7-days"
+)
 
 type RefundPolicy string
 
-const RefundPolicyConditionalRefund RefundPolicy = "conditional-refund"
-const RefundPolicyCustomPolicy RefundPolicy = "custom-policy"
-const RefundPolicyEventBasedPolicy RefundPolicy = "event-based-policy"
-const RefundPolicyFullRefundExtendedWindow RefundPolicy = "full-refund-extended-window"
-const RefundPolicyFullRefundWithin30Days RefundPolicy = "full-refund-within-30-days"
-const RefundPolicyNoRefunds RefundPolicy = "no-refunds"
-const RefundPolicyPartialRefund RefundPolicy = "partial-refund"
-const RefundPolicyProratedRefund RefundPolicy = "prorated-refund"
-const RefundPolicyStoreCreditOnly RefundPolicy = "store-credit-only"
+const (
+	RefundPolicyConditionalRefund        RefundPolicy = "conditional-refund"
+	RefundPolicyCustomPolicy             RefundPolicy = "custom-policy"
+	RefundPolicyEventBasedPolicy         RefundPolicy = "event-based-policy"
+	RefundPolicyFullRefundExtendedWindow RefundPolicy = "full-refund-extended-window"
+	RefundPolicyFullRefundWithin30Days   RefundPolicy = "full-refund-within-30-days"
+	RefundPolicyNoRefunds                RefundPolicy = "no-refunds"
+	RefundPolicyPartialRefund            RefundPolicy = "partial-refund"
+	RefundPolicyProratedRefund           RefundPolicy = "prorated-refund"
+	RefundPolicyStoreCreditOnly          RefundPolicy = "store-credit-only"
+)
 
 type MoneyTransfer struct {
 	PullFromCard *MoneyTransferPullFromCard `json:"pullFromCard,omitempty"`


### PR DESCRIPTION
## Changes
Updates to moov-go granular capabilities. This adds similar generic implementation as seen in https://github.com/moovfinancial/moov-go/pull/208 to support verioned calls to the API from the SDK.

## Associated tickets
* COR-3762