### PR TITLE
update 404 message for link card request

### DIFF
--- a/pkg/moov/cards.go
+++ b/pkg/moov/cards.go
@@ -116,7 +116,7 @@ func (c Client) CreateCard(ctx context.Context, accountID string, card CreateCar
 	case StatusCompleted:
 		return UnmarshalObjectResponse[Card](resp)
 	case StatusNotFound:
-		return nil, errors.Join(ErrAccountNotFound, resp)
+		return nil, errors.Join(ErrResourceNotFound, resp)
 	case StatusStateConflict:
 		return nil, errors.Join(ErrAlreadyExists, resp)
 	default:

--- a/pkg/moov/errors.go
+++ b/pkg/moov/errors.go
@@ -30,6 +30,7 @@ func errorAsA[A interface{}](err error) *A {
 var (
 	ErrCredentialsNotSet            = errors.New("api credentials not set")
 	ErrAccountNotFound              = errors.New("no account with the specified accountID was found")
+	ErrResourceNotFound             = errors.New("the requested resource was not found")
 	ErrAlreadyExists                = errors.New("resource already exists")
 	ErrMicroDepositAmountsIncorrect = errors.New("the amounts provided are incorrect or the bank account is in an unexpected state")
 	ErrInstantVerificationFailed    = errors.New("attempted verification failed")


### PR DESCRIPTION
The `POST /accounts/{accountID}/cards` endpoint can return a 404 for a number of reasons, not only as a result of the accountID in the URL.