### PR TITLE
webhooks: Fully deprecate account.deleted and add new account.disconnected webhook

### DIFF
--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -33,7 +33,7 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 	switch event.EventType {
 	case EventTypeAccountCreated:
 		eventData = &event.accountCreated
-	case EventTypeAccountDeleted:
+	case EventTypeAccountDisconnected:
 		eventData = &event.accountDeleted
 	case EventTypeAccountUpdated:
 		eventData = &event.accountUpdated
@@ -106,7 +106,7 @@ type Event struct {
 	Data      json.RawMessage `json:"data"`
 
 	accountCreated           *AccountCreated
-	accountDeleted           *AccountDeleted
+	accountDeleted           *AccountDisconnected
 	accountUpdated           *AccountUpdated
 	balanceUpdated           *BalanceUpdated
 	bankAccountCreated       *BankAccountCreated
@@ -143,9 +143,9 @@ func (e Event) AccountCreated() (*AccountCreated, error) {
 	return e.accountCreated, nil
 }
 
-func (e Event) AccountDeleted() (*AccountDeleted, error) {
-	if e.EventType != EventTypeAccountDeleted {
-		return nil, newInvalidEventTypeError(EventTypeAccountDeleted, e.EventType)
+func (e Event) AccountDisconnected() (*AccountDisconnected, error) {
+	if e.EventType != EventTypeAccountDisconnected {
+		return nil, newInvalidEventTypeError(EventTypeAccountDisconnected, e.EventType)
 	}
 
 	return e.accountDeleted, nil

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -10,7 +10,7 @@ type EventType string
 
 const (
 	EventTypeAccountCreated           EventType = "account.created"
-	EventTypeAccountDeleted           EventType = "account.deleted"
+	EventTypeAccountDisconnected      EventType = "account.disconnected"
 	EventTypeAccountUpdated           EventType = "account.updated"
 	EventTypeBalanceUpdated           EventType = "balance.updated"
 	EventTypeBankAccountCreated       EventType = "bankAccount.created"
@@ -45,7 +45,7 @@ type AccountCreated struct {
 	ForeignID string `json:"foreignID,omitempty"`
 }
 
-type AccountDeleted struct {
+type AccountDisconnected struct {
 	// ID of the account
 	AccountID string `json:"accountID"`
 	ForeignID string `json:"foreignID,omitempty"`


### PR DESCRIPTION
1. Remove `account.deleted` webhook since the event/webhook doesn't exist
    - Also, the event type was never included in the event list for customers to subscribe to
2. This PR also adds in the new `account.disconnected` that has the same fields