### PR TITLE
Add support ticket webhooks

### DIFF
--- a/pkg/mhooks/event.go
+++ b/pkg/mhooks/event.go
@@ -81,6 +81,12 @@ func ParseEvent(r *http.Request, secret string) (*Event, error) {
 		eventData = &event.sweepUpdated
 	case EventTypeTestPing:
 		eventData = &event.testPing
+	case EventTypeTicketCreated:
+		eventData = &event.ticketCreated
+	case EventTypeTicketStatusChanged:
+		eventData = &event.ticketStatusChanged
+	case EventTypeTicketMessageAdded:
+		eventData = &event.ticketMessageAdded
 	case EventTypeTransferCreated:
 		eventData = &event.transferCreated
 	case EventTypeTransferUpdated:
@@ -130,6 +136,9 @@ type Event struct {
 	sweepCreated             *SweepCreated
 	sweepUpdated             *SweepUpdated
 	testPing                 *TestPing
+	ticketCreated            *TicketCreated
+	ticketStatusChanged      *TicketStatusChanged
+	ticketMessageAdded       *TicketMessageAdded
 	transferCreated          *TransferCreated
 	transferUpdated          *TransferUpdated
 	walletTransactionUpdated *WalletTransactionUpdated
@@ -333,6 +342,30 @@ func (e Event) TestPing() (*TestPing, error) {
 	}
 
 	return e.testPing, nil
+}
+
+func (e Event) TicketCreated() (*TicketCreated, error) {
+	if e.EventType != EventTypeTicketCreated {
+		return nil, newInvalidEventTypeError(EventTypeTicketCreated, e.EventType)
+	}
+
+	return e.ticketCreated, nil
+}
+
+func (e Event) TicketStatusChanged() (*TicketStatusChanged, error) {
+	if e.EventType != EventTypeTicketStatusChanged {
+		return nil, newInvalidEventTypeError(EventTypeTicketStatusChanged, e.EventType)
+	}
+
+	return e.ticketStatusChanged, nil
+}
+
+func (e Event) TicketMessageAdded() (*TicketMessageAdded, error) {
+	if e.EventType != EventTypeTicketMessageAdded {
+		return nil, newInvalidEventTypeError(EventTypeTicketMessageAdded, e.EventType)
+	}
+
+	return e.ticketMessageAdded, nil
 }
 
 func (e Event) TransferCreated() (*TransferCreated, error) {

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -34,6 +34,9 @@ const (
 	EventTypeSweepCreated             EventType = "sweep.created"
 	EventTypeSweepUpdated             EventType = "sweep.updated"
 	EventTypeTestPing                 EventType = "event.test"
+	EventTypeTicketCreated            EventType = "ticket.created"
+	EventTypeTicketStatusChanged      EventType = "ticket.statusChanged"
+	EventTypeTicketMessageAdded       EventType = "ticket.messageAdded"
 	EventTypeTransferCreated          EventType = "transfer.created"
 	EventTypeTransferUpdated          EventType = "transfer.updated"
 	EventTypeWalletTransactionUpdated EventType = "walletTransaction.updated"
@@ -240,6 +243,29 @@ type SweepUpdated struct {
 
 type TestPing struct {
 	Ping bool `json:"ping"`
+}
+
+type TicketCreated struct {
+	// ID of the account
+	AccountID string `json:"accountID"`
+	// ID of the ticket
+	TicketID string `json:"ticketID"`
+}
+
+type TicketStatusChanged struct {
+	// ID of the account
+	AccountID string `json:"accountID"`
+	// ID of the ticket
+	TicketID string `json:"ticketID"`
+	// Status of the ticket
+	Status moov.TicketStatus `json:"status"`
+}
+
+type TicketMessageAdded struct {
+	// ID of the account
+	AccountID string `json:"accountID"`
+	// ID of the ticket
+	TicketID string `json:"ticketID"`
 }
 
 type TransferCreated struct {


### PR DESCRIPTION
Adds the following webhooks:
- `ticket.created`
```
{
    "accountID": "string",
    "ticketID": "string"
}
```

- `ticket.statusChanged`
```
{
    "accountID": "string",
    "ticketID": "string",
    "status": "string"
}
```

- `ticket.messageAdded`
```
{
    "accountID": "string",
    "ticketID": "string"
}
```