### PR TITLE
feat: [COR-3738] Update to support new account type guest

### DIFF
--- a/pkg/moov/a_test.go
+++ b/pkg/moov/a_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/moovfinancial/moov-go/internal/testtools"
 	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2507"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,6 +43,25 @@ func randomBankAccountNumber() string {
 func createTestIndividualAccount() moov.CreateAccount {
 	return moov.CreateAccount{
 		Type: moov.AccountType_Individual,
+		Profile: moov.CreateProfile{
+			Individual: &moov.CreateIndividualProfile{
+				Name: moov.Name{
+					FirstName: "John",
+					LastName:  "Doe",
+				},
+				Email: "noreply@moov.io",
+				Phone: &moov.Phone{
+					Number:      "555-555-5555",
+					CountryCode: "1",
+				},
+			},
+		},
+	}
+}
+
+func createTestIndividualAccount_V2507() mv2507.CreateAccount {
+	return mv2507.CreateAccount{
+		Type: mv2507.CreateAccountType_Individual,
 		Profile: moov.CreateProfile{
 			Individual: &moov.CreateIndividualProfile{
 				Name: moov.Name{

--- a/pkg/moov/account_api.go
+++ b/pkg/moov/account_api.go
@@ -98,6 +98,14 @@ func (ac AccountClient[T, V]) Disconnect(ctx context.Context, client Client, acc
 // Legacy
 
 // Only use for Preversioned API calls. Use mvxxxx.Accounts.Create(...) instead.
+// CreateAccount creates a new account with the provided configuration.
+//
+// It returns:
+//   - created (*Account): The fully created account when the server responds with a 200 status code.
+//   - started (*Account): The account details when the server responds with a 201 status code.
+//   - err (error): Any error encountered during the account creation process.
+//
+// Only one of created or started will be non-nil, depending on the server's response.
 func (c *Client) CreateAccount(ctx context.Context, account CreateAccount) (created, started *Account, err error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathAccounts),

--- a/pkg/moov/bank_account_models.go
+++ b/pkg/moov/bank_account_models.go
@@ -37,6 +37,7 @@ type HolderType string
 const (
 	HolderType_Individual HolderType = "individual"
 	HolderType_Business   HolderType = "business"
+	HolderType_Guest      HolderType = "guest"
 )
 
 type PlaidRequest struct {

--- a/pkg/mv2507/account_models.go
+++ b/pkg/mv2507/account_models.go
@@ -1,0 +1,75 @@
+package mv2507
+
+import (
+	"time"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+var Accounts = moov.AccountClient[CreateAccount, Account]{Version: moov.Version2025_07}
+
+type CreateAccount struct {
+	Type                  CreateAccountType           `json:"accountType"`
+	Profile               moov.CreateProfile          `json:"profile"`
+	Metadata              map[string]string           `json:"metadata,omitempty"`
+	TermsOfService        *moov.TermsOfServicePayload `json:"termsOfService,omitempty"`
+	ForeignID             string                      `json:"foreignID,omitempty"`
+	CustomerSupport       *moov.CustomerSupport       `json:"customerSupport,omitempty"`
+	AccountSettings       *moov.AccountSettings       `json:"settings,omitempty"`
+	RequestedCapabilities []moov.CapabilityName       `json:"capabilities,omitempty"`
+}
+
+// CreateAccountType The type of entity represented by this account to be created.
+type CreateAccountType AccountType
+
+// List of CreateAccountType
+const (
+	CreateAccountType_Individual CreateAccountType = "individual"
+	CreateAccountType_Business   CreateAccountType = "business"
+)
+
+// Account Describes a Moov account.
+type Account struct {
+	Mode        moov.Mode   `json:"mode,omitempty"`
+	AccountID   string      `json:"accountID,omitempty"`
+	AccountType AccountType `json:"accountType,omitempty"`
+	DisplayName string      `json:"displayName,omitempty"`
+	Profile     Profile     `json:"profile,omitempty"`
+	// Free-form key-value pair list. Useful for storing information that is not captured elsewhere.
+	Metadata       map[string]string        `json:"metadata,omitempty"`
+	TermsOfService *moov.TermsOfService     `json:"termsOfService,omitempty"`
+	Capabilities   []moov.AccountCapability `json:"capabilities,omitempty"`
+	Verification   moov.Verification        `json:"verification,omitempty"`
+	// Optional alias from a foreign/external system which can be used to reference this resource.
+	ForeignID       string                `json:"foreignID,omitempty"`
+	CustomerSupport *moov.CustomerSupport `json:"customerSupport,omitempty"`
+	Settings        *moov.AccountSettings `json:"settings,omitempty"`
+	CreatedOn       time.Time             `json:"createdOn,omitempty"`
+	UpdatedOn       time.Time             `json:"updatedOn,omitempty"`
+	DisconnectedOn  *time.Time            `json:"disconnectedOn,omitempty"`
+}
+
+// AccountType The type of entity represented by this account.
+type AccountType string
+
+// List of AccountType
+const (
+	AccountType_Individual AccountType = "individual"
+	AccountType_Business   AccountType = "business"
+	AccountType_Guest      AccountType = "guest"
+)
+
+// Profile Describes a Moov account profile.
+type Profile struct {
+	Individual *moov.Individual `json:"individual,omitempty"`
+	Business   *moov.Business   `json:"business,omitempty"`
+	Guest      *Guest           `json:"guest,omitempty"`
+}
+
+// Guest Describes a guest account profile.
+type Guest struct {
+	Name  string      `json:"name,omitempty"`
+	Phone *moov.Phone `json:"phone,omitempty"`
+	// Email address.
+	Email string `json:"email,omitempty"`
+}


### PR DESCRIPTION
Update to support new account type guest on v2025.07.00 or later
* adds similar generic implementation as seen in https://github.com/moovfinancial/moov-go/pull/208 to support versioned calls to the API from the SDK
* guest accounts cannot be created directly through the API or SDK, but can be retrieved after they've been created by Moov internal processes