### PR TITLE
feat: Add `AmountDetails` to Transfer models

### DIFF
--- a/examples/transfers/transfer_config_test.go
+++ b/examples/transfers/transfer_config_test.go
@@ -1,0 +1,75 @@
+package transfers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+func ExampleClient_CreateTransferConfig() {
+	mc, err := moov.NewClient()
+	if err != nil {
+		fmt.Printf("new Moov client: %v\n", err)
+		return
+	}
+
+	config, err := mc.CreateTransferConfig(context.Background(),
+		"00000000-00000000-00000000-00000000",
+		moov.CreateTransferConfig{
+			TipPresets: &moov.CreateTipPresets{
+				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PreTax),
+				PercentageOptions: []int{10, 15, 20},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("creating transfer config: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Created transfer config: %+v", config)
+}
+
+func ExampleClient_GetTransferConfig() {
+	mc, err := moov.NewClient()
+	if err != nil {
+		fmt.Printf("new Moov client: %v\n", err)
+		return
+	}
+
+	config, err := mc.GetTransferConfig(context.Background(), "00000000-00000000-00000000-00000000")
+	if err != nil {
+		fmt.Printf("getting transfer config: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Got transfer config: %+v", config)
+}
+
+func ExampleClient_UpdateTransferConfig() {
+	mc, err := moov.NewClient()
+	if err != nil {
+		fmt.Printf("new Moov client: %v\n", err)
+		return
+	}
+
+	config, err := mc.UpdateTransferConfig(context.Background(),
+		"00000000-00000000-00000000-00000000",
+		moov.PutTransferConfig{
+			TipPresets: moov.PutTipPresets{
+				FixedAmountOptions: []moov.AmountDecimal{
+					{Currency: "USD", ValueDecimal: "1.00"},
+					{Currency: "USD", ValueDecimal: "2.00"},
+					{Currency: "USD", ValueDecimal: "5.00"},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("updating transfer config: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Updated transfer config: %+v", config)
+}

--- a/examples/transfers/transfer_config_test.go
+++ b/examples/transfers/transfer_config_test.go
@@ -16,8 +16,8 @@ func ExampleClient_CreateTransferConfig() {
 
 	config, err := mc.CreateTransferConfig(context.Background(),
 		"00000000-00000000-00000000-00000000",
-		moov.CreateTransferConfig{
-			TipPresets: &moov.CreateTipPresets{
+		moov.UpsertTransferConfig{
+			TipPresets: &moov.UpsertTipPresets{
 				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PreTax),
 				PercentageOptions: []int{10, 15, 20},
 			},
@@ -56,8 +56,8 @@ func ExampleClient_UpdateTransferConfig() {
 
 	config, err := mc.UpdateTransferConfig(context.Background(),
 		"00000000-00000000-00000000-00000000",
-		moov.PutTransferConfig{
-			TipPresets: moov.PutTipPresets{
+		moov.UpsertTransferConfig{
+			TipPresets: &moov.UpsertTipPresets{
 				FixedAmountOptions: []moov.AmountDecimal{
 					{Currency: "USD", ValueDecimal: "1.00"},
 					{Currency: "USD", ValueDecimal: "2.00"},

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -68,6 +68,7 @@ const (
 	pathInstitutions = "/institutions"
 
 	pathTransferOptions = "/accounts/%s/transfer-options"
+	pathTransferConfig  = "/accounts/%s/transfer-config"
 
 	pathTransfers = "/accounts/%s/transfers"
 	pathTransfer  = "/accounts/%s/transfers/%s"

--- a/pkg/moov/schedules_model.go
+++ b/pkg/moov/schedules_model.go
@@ -384,7 +384,7 @@ type ScheduledTransferImageMetadata struct {
 }
 
 type ScheduledAmountDetails struct {
-	TipAmount       *AmountDecimal `json:"tip"`
-	TaxAmount       *AmountDecimal `json:"tax"`
-	SurchargeAmount *AmountDecimal `json:"surcharge"`
+	TipAmount       *AmountDecimal `json:"tip,omitempty"`
+	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
+	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
 }

--- a/pkg/moov/schedules_model.go
+++ b/pkg/moov/schedules_model.go
@@ -172,8 +172,7 @@ type CreateOccurrence struct {
 type CreateRunTransfer struct {
 	Description string `json:"description"`
 
-	Amount ScheduleAmount `json:"amount"`
-	// Deprecated: use AmountDetails.TaxAmount
+	Amount         ScheduleAmount                `json:"amount"`
 	SalesTaxAmount *ScheduleAmount               `json:"salesTaxAmount,omitempty"`
 	AmountDetails  *CreateScheduledAmountDetails `json:"amountDetails,omitempty"`
 
@@ -217,9 +216,7 @@ type CreateScheduledTransferLineItemOption struct {
 }
 
 type CreateScheduledAmountDetails struct {
-	TipAmount       *AmountDecimal `json:"tip,omitempty"`
-	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
-	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
+	TipAmount *AmountDecimal `json:"tip,omitempty"`
 }
 
 type UpdateSchedule struct {
@@ -250,8 +247,7 @@ type UpdateOccurrence struct {
 type RunTransfer struct {
 	Description string `json:"description,omitempty"`
 
-	Amount ScheduleAmount `json:"amount,omitempty"`
-	// Deprecated: use AmountDetails.TaxAmount
+	Amount         ScheduleAmount          `json:"amount,omitempty"`
 	SalesTaxAmount *ScheduleAmount         `json:"salesTaxAmount,omitempty"`
 	AmountDetails  *ScheduledAmountDetails `json:"amountDetails,omitempty"`
 
@@ -274,9 +270,7 @@ func (r RunTransfer) ToCreateRunTransfer() CreateRunTransfer {
 
 	if r.AmountDetails != nil {
 		crt.AmountDetails = &CreateScheduledAmountDetails{
-			TipAmount:       r.AmountDetails.TipAmount,
-			TaxAmount:       r.AmountDetails.TaxAmount,
-			SurchargeAmount: r.AmountDetails.SurchargeAmount,
+			TipAmount: r.AmountDetails.TipAmount,
 		}
 	}
 
@@ -384,7 +378,5 @@ type ScheduledTransferImageMetadata struct {
 }
 
 type ScheduledAmountDetails struct {
-	TipAmount       *AmountDecimal `json:"tip,omitempty"`
-	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
-	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
+	TipAmount *AmountDecimal `json:"tip,omitempty"`
 }

--- a/pkg/moov/schedules_model.go
+++ b/pkg/moov/schedules_model.go
@@ -172,8 +172,10 @@ type CreateOccurrence struct {
 type CreateRunTransfer struct {
 	Description string `json:"description"`
 
-	Amount         ScheduleAmount  `json:"amount"`
-	SalesTaxAmount *ScheduleAmount `json:"salesTaxAmount,omitempty"`
+	Amount ScheduleAmount `json:"amount"`
+	// Deprecated: use AmountDetails.TaxAmount
+	SalesTaxAmount *ScheduleAmount               `json:"salesTaxAmount,omitempty"`
+	AmountDetails  *CreateScheduledAmountDetails `json:"amountDetails,omitempty"`
 
 	PartnerAccountID string                            `json:"partnerAccountID"`
 	Source           SchedulePaymentMethod             `json:"source"`
@@ -214,6 +216,12 @@ type CreateScheduledTransferLineItemOption struct {
 	Group *string `json:"group,omitempty"`
 }
 
+type CreateScheduledAmountDetails struct {
+	TipAmount       *AmountDecimal `json:"tip,omitempty"`
+	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
+	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
+}
+
 type UpdateSchedule struct {
 	// Description of what this schedule is
 	Description string `json:"description,omitempty"`
@@ -242,8 +250,10 @@ type UpdateOccurrence struct {
 type RunTransfer struct {
 	Description string `json:"description,omitempty"`
 
-	Amount         ScheduleAmount  `json:"amount,omitempty"`
-	SalesTaxAmount *ScheduleAmount `json:"salesTaxAmount,omitempty"`
+	Amount ScheduleAmount `json:"amount,omitempty"`
+	// Deprecated: use AmountDetails.TaxAmount
+	SalesTaxAmount *ScheduleAmount         `json:"salesTaxAmount,omitempty"`
+	AmountDetails  *ScheduledAmountDetails `json:"amountDetails,omitempty"`
 
 	PartnerAccountID string                `json:"partnerAccountID,omitempty"`
 	Source           SchedulePaymentMethod `json:"source,omitempty"`
@@ -260,6 +270,14 @@ func (r RunTransfer) ToCreateRunTransfer() CreateRunTransfer {
 		PartnerAccountID: r.PartnerAccountID,
 		Source:           r.Source,
 		Destination:      r.Destination,
+	}
+
+	if r.AmountDetails != nil {
+		crt.AmountDetails = &CreateScheduledAmountDetails{
+			TipAmount:       r.AmountDetails.TipAmount,
+			TaxAmount:       r.AmountDetails.TaxAmount,
+			SurchargeAmount: r.AmountDetails.SurchargeAmount,
+		}
 	}
 
 	if r.LineItems != nil {
@@ -363,4 +381,10 @@ type ScheduledTransferImageMetadata struct {
 	Link string `json:"link"`
 	// A unique identifier for an image, used in public image links.
 	PublicID string `json:"publicID" validate:"regexp=[A-Za-z0-9_-]{21}"`
+}
+
+type ScheduledAmountDetails struct {
+	TipAmount       *AmountDecimal `json:"tip"`
+	TaxAmount       *AmountDecimal `json:"tax"`
+	SurchargeAmount *AmountDecimal `json:"surcharge"`
 }

--- a/pkg/moov/schedules_model.go
+++ b/pkg/moov/schedules_model.go
@@ -172,9 +172,8 @@ type CreateOccurrence struct {
 type CreateRunTransfer struct {
 	Description string `json:"description"`
 
-	Amount         ScheduleAmount                `json:"amount"`
-	SalesTaxAmount *ScheduleAmount               `json:"salesTaxAmount,omitempty"`
-	AmountDetails  *CreateScheduledAmountDetails `json:"amountDetails,omitempty"`
+	Amount         ScheduleAmount  `json:"amount"`
+	SalesTaxAmount *ScheduleAmount `json:"salesTaxAmount,omitempty"`
 
 	PartnerAccountID string                            `json:"partnerAccountID"`
 	Source           SchedulePaymentMethod             `json:"source"`
@@ -215,10 +214,6 @@ type CreateScheduledTransferLineItemOption struct {
 	Group *string `json:"group,omitempty"`
 }
 
-type CreateScheduledAmountDetails struct {
-	TipAmount *AmountDecimal `json:"tip,omitempty"`
-}
-
 type UpdateSchedule struct {
 	// Description of what this schedule is
 	Description string `json:"description,omitempty"`
@@ -247,9 +242,8 @@ type UpdateOccurrence struct {
 type RunTransfer struct {
 	Description string `json:"description,omitempty"`
 
-	Amount         ScheduleAmount          `json:"amount,omitempty"`
-	SalesTaxAmount *ScheduleAmount         `json:"salesTaxAmount,omitempty"`
-	AmountDetails  *ScheduledAmountDetails `json:"amountDetails,omitempty"`
+	Amount         ScheduleAmount  `json:"amount,omitempty"`
+	SalesTaxAmount *ScheduleAmount `json:"salesTaxAmount,omitempty"`
 
 	PartnerAccountID string                `json:"partnerAccountID,omitempty"`
 	Source           SchedulePaymentMethod `json:"source,omitempty"`
@@ -266,12 +260,6 @@ func (r RunTransfer) ToCreateRunTransfer() CreateRunTransfer {
 		PartnerAccountID: r.PartnerAccountID,
 		Source:           r.Source,
 		Destination:      r.Destination,
-	}
-
-	if r.AmountDetails != nil {
-		crt.AmountDetails = &CreateScheduledAmountDetails{
-			TipAmount: r.AmountDetails.TipAmount,
-		}
 	}
 
 	if r.LineItems != nil {
@@ -375,8 +363,4 @@ type ScheduledTransferImageMetadata struct {
 	Link string `json:"link"`
 	// A unique identifier for an image, used in public image links.
 	PublicID string `json:"publicID" validate:"regexp=[A-Za-z0-9_-]{21}"`
-}
-
-type ScheduledAmountDetails struct {
-	TipAmount *AmountDecimal `json:"tip,omitempty"`
 }

--- a/pkg/moov/transfer_config_api.go
+++ b/pkg/moov/transfer_config_api.go
@@ -17,7 +17,7 @@ func (c Client) CreateTransferConfig(ctx context.Context, accountID string, crea
 		return nil, err
 	}
 
-	return CompletedObjectOrError[TransferConfig](resp)
+	return StartedObjectOrError[TransferConfig](resp)
 }
 
 // GetTransferConfig retrieves the transfer config for the specified account.

--- a/pkg/moov/transfer_config_api.go
+++ b/pkg/moov/transfer_config_api.go
@@ -17,7 +17,7 @@ func (c Client) CreateTransferConfig(ctx context.Context, accountID string, crea
 		return nil, err
 	}
 
-	return StartedObjectOrError[TransferConfig](resp)
+	return CompletedObjectOrError[TransferConfig](resp)
 }
 
 // GetTransferConfig retrieves the transfer config for the specified account.

--- a/pkg/moov/transfer_config_api.go
+++ b/pkg/moov/transfer_config_api.go
@@ -1,0 +1,50 @@
+package moov
+
+import (
+	"context"
+	"net/http"
+)
+
+// CreateTransferConfig creates a transfer config for the specified account.
+func (c Client) CreateTransferConfig(ctx context.Context, accountID string, create CreateTransferConfig) (*TransferConfig, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathTransferConfig, accountID),
+		MoovVersion(Version2026_04),
+		AcceptJson(),
+		JsonBody(create),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return StartedObjectOrError[TransferConfig](resp)
+}
+
+// GetTransferConfig retrieves the transfer config for the specified account.
+func (c Client) GetTransferConfig(ctx context.Context, accountID string) (*TransferConfig, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathTransferConfig, accountID),
+		MoovVersion(Version2026_04),
+		AcceptJson(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TransferConfig](resp)
+}
+
+// UpdateTransferConfig replaces the transfer config for the specified account.
+func (c Client) UpdateTransferConfig(ctx context.Context, accountID string, update PutTransferConfig) (*TransferConfig, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodPut, pathTransferConfig, accountID),
+		MoovVersion(Version2026_04),
+		AcceptJson(),
+		JsonBody(update),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TransferConfig](resp)
+}

--- a/pkg/moov/transfer_config_api.go
+++ b/pkg/moov/transfer_config_api.go
@@ -6,12 +6,12 @@ import (
 )
 
 // CreateTransferConfig creates a transfer config for the specified account.
-func (c Client) CreateTransferConfig(ctx context.Context, accountID string, create CreateTransferConfig) (*TransferConfig, error) {
+func (c Client) CreateTransferConfig(ctx context.Context, accountID string, config UpsertTransferConfig) (*TransferConfig, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPost, pathTransferConfig, accountID),
 		MoovVersion(Version2026_04),
 		AcceptJson(),
-		JsonBody(create),
+		JsonBody(config),
 	)
 	if err != nil {
 		return nil, err
@@ -35,12 +35,12 @@ func (c Client) GetTransferConfig(ctx context.Context, accountID string) (*Trans
 }
 
 // UpdateTransferConfig replaces the transfer config for the specified account.
-func (c Client) UpdateTransferConfig(ctx context.Context, accountID string, update PutTransferConfig) (*TransferConfig, error) {
+func (c Client) UpdateTransferConfig(ctx context.Context, accountID string, config UpsertTransferConfig) (*TransferConfig, error) {
 	resp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPut, pathTransferConfig, accountID),
 		MoovVersion(Version2026_04),
 		AcceptJson(),
-		JsonBody(update),
+		JsonBody(config),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/moov/transfer_config_models.go
+++ b/pkg/moov/transfer_config_models.go
@@ -12,25 +12,13 @@ type TipPresets struct {
 	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`
 }
 
-// CreateTransferConfig request payload for creating a transfer config.
-type CreateTransferConfig struct {
-	TipPresets *CreateTipPresets `json:"tipPresets,omitempty"`
+// UpsertTransferConfig request payload for creating or replacing a transfer config.
+type UpsertTransferConfig struct {
+	TipPresets *UpsertTipPresets `json:"tipPresets,omitempty"`
 }
 
-// CreateTipPresets suggested customer tip values for transfer config creation.
-type CreateTipPresets struct {
-	CalculationBasis   *TipCalculationBasis `json:"calculationBasis,omitempty"`
-	PercentageOptions  []int                `json:"percentageOptions,omitempty"`
-	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`
-}
-
-// PutTransferConfig request payload for replacing a transfer config.
-type PutTransferConfig struct {
-	TipPresets PutTipPresets `json:"tipPresets"`
-}
-
-// PutTipPresets suggested customer tip values for transfer config replacement.
-type PutTipPresets struct {
+// UpsertTipPresets suggested customer tip values for transfer config creation or replacement.
+type UpsertTipPresets struct {
 	CalculationBasis   *TipCalculationBasis `json:"calculationBasis,omitempty"`
 	PercentageOptions  []int                `json:"percentageOptions,omitempty"`
 	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`

--- a/pkg/moov/transfer_config_models.go
+++ b/pkg/moov/transfer_config_models.go
@@ -1,0 +1,59 @@
+package moov
+
+// TransferConfig configurable options for a transfer.
+type TransferConfig struct {
+	TipPresets *TipPresets `json:"tipPresets,omitempty"`
+}
+
+// TipPresets suggested customer tip values for a transfer.
+type TipPresets struct {
+	CalculationBasis   *TipCalculationBasis `json:"calculationBasis,omitempty"`
+	PercentageOptions  []int                `json:"percentageOptions,omitempty"`
+	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`
+}
+
+// CreateTransferConfig request payload for creating a transfer config.
+type CreateTransferConfig struct {
+	TipPresets *CreateTipPresets `json:"tipPresets,omitempty"`
+}
+
+// CreateTipPresets suggested customer tip values for transfer config creation.
+type CreateTipPresets struct {
+	CalculationBasis   *TipCalculationBasis `json:"calculationBasis,omitempty"`
+	PercentageOptions  []int                `json:"percentageOptions,omitempty"`
+	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`
+}
+
+// PutTransferConfig request payload for replacing a transfer config.
+type PutTransferConfig struct {
+	TipPresets PutTipPresets `json:"tipPresets"`
+}
+
+// PutTipPresets suggested customer tip values for transfer config replacement.
+type PutTipPresets struct {
+	CalculationBasis   *TipCalculationBasis `json:"calculationBasis,omitempty"`
+	PercentageOptions  []int                `json:"percentageOptions,omitempty"`
+	FixedAmountOptions []AmountDecimal      `json:"fixedAmountOptions,omitempty"`
+}
+
+// TipCalculationBasis which subtotal should be used for percentage tip calculations.
+type TipCalculationBasis string
+
+// List of TipCalculationBasis
+const (
+	TipCalculationBasis_PreTax  TipCalculationBasis = "pre-tax"
+	TipCalculationBasis_PostTax TipCalculationBasis = "post-tax"
+)
+
+// TransferConfigValidationError validation details for transfer config requests.
+type TransferConfigValidationError struct {
+	TipPresetsCalculationBasis   *string                                 `json:"TipPresets.CalculationBasis,omitempty"`
+	TipPresetsPercentageOptions  map[string]string                       `json:"TipPresets.PercentageOptions,omitempty"`
+	TipPresetsFixedAmountOptions map[string]AmountDecimalValidationError `json:"TipPresets.FixedAmountOptions,omitempty"`
+}
+
+// AmountDecimalValidationError validation details for AmountDecimal fields.
+type AmountDecimalValidationError struct {
+	Currency     *string `json:"currency,omitempty"`
+	ValueDecimal *string `json:"valueDecimal,omitempty"`
+}

--- a/pkg/moov/transfer_config_test.go
+++ b/pkg/moov/transfer_config_test.go
@@ -1,0 +1,90 @@
+package moov_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TransferConfig(t *testing.T) {
+	t.Run("create get update", func(t *testing.T) {
+		mc := NewTestClient(t)
+		account := CreateTemporaryTestAccount(t, mc, createTestIndividualAccount())
+
+		create := moov.CreateTransferConfig{
+			TipPresets: &moov.CreateTipPresets{
+				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PreTax),
+				PercentageOptions: []int{10, 15, 20},
+			},
+		}
+
+		created, err := mc.CreateTransferConfig(BgCtx(), account.AccountID, create)
+		NoResponseError(t, err)
+		require.NotNil(t, created)
+		require.NotNil(t, created.TipPresets)
+		require.Equal(t, moov.PtrOf(moov.TipCalculationBasis_PreTax), created.TipPresets.CalculationBasis)
+		require.Equal(t, []int{10, 15, 20}, created.TipPresets.PercentageOptions)
+
+		got, err := mc.GetTransferConfig(BgCtx(), account.AccountID)
+		NoResponseError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, created, got)
+
+		updateFixed := moov.PutTransferConfig{
+			TipPresets: moov.PutTipPresets{
+				FixedAmountOptions: []moov.AmountDecimal{
+					{Currency: "USD", ValueDecimal: "1.00"},
+					{Currency: "USD", ValueDecimal: "2.00"},
+					{Currency: "USD", ValueDecimal: "5.00"},
+				},
+			},
+		}
+
+		updatedFixed, err := mc.UpdateTransferConfig(BgCtx(), account.AccountID, updateFixed)
+		NoResponseError(t, err)
+		require.NotNil(t, updatedFixed)
+		require.NotNil(t, updatedFixed.TipPresets)
+		require.Equal(t, updateFixed.TipPresets.FixedAmountOptions, updatedFixed.TipPresets.FixedAmountOptions)
+
+		updatePercentages := moov.PutTransferConfig{
+			TipPresets: moov.PutTipPresets{
+				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PostTax),
+				PercentageOptions: []int{12, 18, 25},
+			},
+		}
+
+		updatedPercentages, err := mc.UpdateTransferConfig(BgCtx(), account.AccountID, updatePercentages)
+		NoResponseError(t, err)
+		require.NotNil(t, updatedPercentages)
+		require.NotNil(t, updatedPercentages.TipPresets)
+		require.Equal(t, moov.PtrOf(moov.TipCalculationBasis_PostTax), updatedPercentages.TipPresets.CalculationBasis)
+		require.Equal(t, []int{12, 18, 25}, updatedPercentages.TipPresets.PercentageOptions)
+	})
+
+	t.Run("validation error json", func(t *testing.T) {
+		payload := []byte(`{
+			"TipPresets.CalculationBasis": "must be a valid value",
+			"TipPresets.PercentageOptions": {
+				"0": "must be between 0 and 100"
+			},
+			"TipPresets.FixedAmountOptions": {
+				"0": {
+					"currency": "must be present",
+					"valueDecimal": "must be positive"
+				}
+			}
+		}`)
+
+		var actual moov.TransferConfigValidationError
+		err := json.Unmarshal(payload, &actual)
+		require.NoError(t, err)
+		require.NotNil(t, actual.TipPresetsCalculationBasis)
+		require.Equal(t, "must be a valid value", *actual.TipPresetsCalculationBasis)
+		require.Equal(t, map[string]string{"0": "must be between 0 and 100"}, actual.TipPresetsPercentageOptions)
+		require.Contains(t, actual.TipPresetsFixedAmountOptions, "0")
+		require.Equal(t, "must be present", *actual.TipPresetsFixedAmountOptions["0"].Currency)
+		require.Equal(t, "must be positive", *actual.TipPresetsFixedAmountOptions["0"].ValueDecimal)
+	})
+}

--- a/pkg/moov/transfer_config_test.go
+++ b/pkg/moov/transfer_config_test.go
@@ -13,8 +13,8 @@ func Test_TransferConfig(t *testing.T) {
 		mc := NewTestClient(t)
 		account := CreateTemporaryTestAccount(t, mc, createTestIndividualAccount())
 
-		create := moov.CreateTransferConfig{
-			TipPresets: &moov.CreateTipPresets{
+		create := moov.UpsertTransferConfig{
+			TipPresets: &moov.UpsertTipPresets{
 				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PreTax),
 				PercentageOptions: []int{10, 15, 20},
 			},
@@ -32,8 +32,8 @@ func Test_TransferConfig(t *testing.T) {
 		require.NotNil(t, got)
 		require.Equal(t, created, got)
 
-		updateFixed := moov.PutTransferConfig{
-			TipPresets: moov.PutTipPresets{
+		updateFixed := moov.UpsertTransferConfig{
+			TipPresets: &moov.UpsertTipPresets{
 				FixedAmountOptions: []moov.AmountDecimal{
 					{Currency: "USD", ValueDecimal: "1.00"},
 					{Currency: "USD", ValueDecimal: "2.00"},
@@ -46,10 +46,11 @@ func Test_TransferConfig(t *testing.T) {
 		NoResponseError(t, err)
 		require.NotNil(t, updatedFixed)
 		require.NotNil(t, updatedFixed.TipPresets)
+		require.NotNil(t, updateFixed.TipPresets)
 		require.Equal(t, updateFixed.TipPresets.FixedAmountOptions, updatedFixed.TipPresets.FixedAmountOptions)
 
-		updatePercentages := moov.PutTransferConfig{
-			TipPresets: moov.PutTipPresets{
+		updatePercentages := moov.UpsertTransferConfig{
+			TipPresets: &moov.UpsertTipPresets{
 				CalculationBasis:  moov.PtrOf(moov.TipCalculationBasis_PostTax),
 				PercentageOptions: []int{12, 18, 25},
 			},

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -4,10 +4,14 @@ import "time"
 
 // CreateTransfer struct for CreateTransfer
 type CreateTransfer struct {
-	Source         CreateTransfer_Source         `json:"source"`
-	Destination    CreateTransfer_Destination    `json:"destination"`
-	Amount         Amount                        `json:"amount"`
-	SalesTaxAmount *Amount                       `json:"salesTaxAmount,omitempty"`
+	Source      CreateTransfer_Source      `json:"source"`
+	Destination CreateTransfer_Destination `json:"destination"`
+
+	Amount Amount `json:"amount"`
+	// Deprecated: use AmountDetails.TaxAmount
+	SalesTaxAmount *Amount                      `json:"salesTaxAmount,omitempty"`
+	AmountDetails  *CreateTransferAmountDetails `json:"amountDetails,omitempty"`
+
 	FacilitatorFee CreateTransfer_FacilitatorFee `json:"facilitatorFee,omitempty"`
 	// An optional description of the transfer for your own internal use.
 	Description string `json:"description,omitempty"`
@@ -115,6 +119,15 @@ type CreateTransferLineItemOption struct {
 	Group         *string        `json:"group,omitempty"`
 }
 
+type CreateTransferAmountDetails struct {
+	// Optional tip amount
+	TipAmount *AmountDecimal `json:"tip,omitempty"`
+	// Optional tax amount
+	TaxAmount *AmountDecimal `json:"tax,omitempty"`
+	// Optional surcharge amount
+	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
+}
+
 // TransferStarted is where the request to create a transfer was recorded and kicked off but hasn't completed yet
 type TransferStarted struct {
 	// Identifier for the transfer.
@@ -169,8 +182,11 @@ type Transfer struct {
 	// A list of cancellations for a transfer.
 	Cancellations []Cancellation `json:"cancellations,omitempty"`
 
+	// Deprecated: use AmountDetails.TaxAmount
 	// Optional sales tax amount. Transfer.Amount.Value should be inclusive of any sales tax and represents the total amount charged.
 	SalesTaxAmount *Amount `json:"salesTaxAmount,omitempty"`
+
+	AmountDetails *TransferAmountDetails `json:"amountDetails,omitempty"`
 
 	PaymentLinkCode *string `json:"paymentLinkCode,omitempty"`
 
@@ -472,6 +488,12 @@ type TransferLineItemImageMetadata struct {
 	AltText  *string `json:"altText,omitempty"`
 	Link     string  `json:"link"`
 	PublicID string  `json:"publicID"`
+}
+
+type TransferAmountDetails struct {
+	TipAmount       *AmountDecimal `json:"tip"`
+	TaxAmount       *AmountDecimal `json:"tax"`
+	SurchargeAmount *AmountDecimal `json:"surcharge"`
 }
 
 /* ======== enumerations ======== */

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -7,8 +7,7 @@ type CreateTransfer struct {
 	Source      CreateTransfer_Source      `json:"source"`
 	Destination CreateTransfer_Destination `json:"destination"`
 
-	Amount Amount `json:"amount"`
-	// Deprecated: use AmountDetails.TaxAmount
+	Amount         Amount                       `json:"amount"`
 	SalesTaxAmount *Amount                      `json:"salesTaxAmount,omitempty"`
 	AmountDetails  *CreateTransferAmountDetails `json:"amountDetails,omitempty"`
 
@@ -122,10 +121,6 @@ type CreateTransferLineItemOption struct {
 type CreateTransferAmountDetails struct {
 	// Optional tip amount
 	TipAmount *AmountDecimal `json:"tip,omitempty"`
-	// Optional tax amount
-	TaxAmount *AmountDecimal `json:"tax,omitempty"`
-	// Optional surcharge amount
-	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
 }
 
 // TransferStarted is where the request to create a transfer was recorded and kicked off but hasn't completed yet
@@ -182,7 +177,6 @@ type Transfer struct {
 	// A list of cancellations for a transfer.
 	Cancellations []Cancellation `json:"cancellations,omitempty"`
 
-	// Deprecated: use AmountDetails.TaxAmount
 	// Optional sales tax amount. Transfer.Amount.Value should be inclusive of any sales tax and represents the total amount charged.
 	SalesTaxAmount *Amount `json:"salesTaxAmount,omitempty"`
 
@@ -491,9 +485,7 @@ type TransferLineItemImageMetadata struct {
 }
 
 type TransferAmountDetails struct {
-	TipAmount       *AmountDecimal `json:"tip,omitempty"`
-	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
-	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
+	TipAmount *AmountDecimal `json:"tip,omitempty"`
 }
 
 /* ======== enumerations ======== */

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -491,9 +491,9 @@ type TransferLineItemImageMetadata struct {
 }
 
 type TransferAmountDetails struct {
-	TipAmount       *AmountDecimal `json:"tip"`
-	TaxAmount       *AmountDecimal `json:"tax"`
-	SurchargeAmount *AmountDecimal `json:"surcharge"`
+	TipAmount       *AmountDecimal `json:"tip,omitempty"`
+	TaxAmount       *AmountDecimal `json:"tax,omitempty"`
+	SurchargeAmount *AmountDecimal `json:"surcharge,omitempty"`
 }
 
 /* ======== enumerations ======== */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive API surface: new client methods/models for transfer config and an optional `amountDetails.tip` field on transfer create/response, with no changes to existing required fields or flows.
> 
> **Overview**
> Adds a new `transfer-config` API to the Go client, including `CreateTransferConfig`, `GetTransferConfig`, and `UpdateTransferConfig` plus models for tip preset configuration (percentage/fixed options and pre/post-tax calculation basis).
> 
> Extends transfer request/response models with optional `amountDetails` (currently supporting `tip`) and includes new unit tests and examples covering transfer config lifecycle and validation-error JSON unmarshalling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be219731538257d17b96e3729895893b805cf1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->