### PR TITLE
feat(CAR-4712): add PayoutType to CreateTransfer_CardDetailsDestination

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-faker/faker/v4 v4.7.0 h1:VboC02cXHl/NuQh5lM2W8b87yp4iFXIu59x4w0RZi4E=
 github.com/go-faker/faker/v4 v4.7.0/go.mod h1:u1dIRP5neLB6kTzgyVjdBOV5R1uP7BdxkcWk7tiKQXk=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -66,6 +66,8 @@ type CreateTransfer_Destination struct {
 type CreateTransfer_CardDetailsDestination struct {
 	// An optional override of the default card statement descriptor for a transfer.
 	DynamicDescriptor string `json:"dynamicDescriptor,omitempty"`
+	// Specifies the payout type for push-to-card disbursements. Use "loyalty" for loyalty payment disbursements.
+	PayoutType string `json:"payoutType,omitempty"`
 }
 
 // CreateTransfer_AchDetailsBase If transfer involves ACH, override default card acceptance properties.

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -66,8 +66,8 @@ type CreateTransfer_Destination struct {
 type CreateTransfer_CardDetailsDestination struct {
 	// An optional override of the default card statement descriptor for a transfer.
 	DynamicDescriptor string `json:"dynamicDescriptor,omitempty"`
-	// Specifies the payout type for push-to-card disbursements. Use "loyalty" for loyalty payment disbursements.
-	PayoutType string `json:"payoutType,omitempty"`
+	// Specifies the payout type for push-to-card disbursements.
+	PayoutType PayoutType `json:"payoutType,omitempty"`
 }
 
 // CreateTransfer_AchDetailsBase If transfer involves ACH, override default card acceptance properties.
@@ -479,6 +479,14 @@ type TransferLineItemImageMetadata struct {
 /* ======== enumerations ======== */
 
 // TransactionSource Specifies the nature and initiator of a transaction. Crucial for recurring and merchant-initiated transactions as per card scheme rules. Omit for customer-initiated e-commerce transactions.  - `first-recurring`: Initial transaction in a recurring series or saving a card for future merchant-initiated charges - `recurring`: Regular, merchant-initiated scheduled transactions - `unscheduled`: Non-regular, merchant-initiated transactions like account top-ups
+// PayoutType specifies the payout type for push-to-card disbursements.
+type PayoutType string
+
+// List of PayoutType
+const (
+	PayoutType_Loyalty PayoutType = "loyalty"
+)
+
 type TransactionSource string
 
 // // List of TransactionSource


### PR DESCRIPTION
## Summary
- Add `PayoutType` field to `CreateTransfer_CardDetailsDestination` for loyalty payment disbursements
- Based on v0.34.0 for platform-dev compatibility

## Test plan
- [x] Build passes
- [x] Integration tests pass in platform-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)