### PR TITLE
feat: add push-to-apple-pay and pull-from-apple-pay constants

### DIFF
--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -135,9 +135,6 @@ func standardDecoder(r io.Reader, contentType string, item any) error {
 func (r *httpCallResponse) Unmarshal(item any) error {
 	ct := strings.ToLower(r.resp.Header.Get("content-type"))
 
-	// TODO: remove debug logging
-	fmt.Printf("DEBUG raw response body: %s\n", r.body)
-
 	if sb, ok := item.(*strings.Builder); ok {
 		_, err := sb.Write(r.body)
 		return err

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -135,6 +135,9 @@ func standardDecoder(r io.Reader, contentType string, item any) error {
 func (r *httpCallResponse) Unmarshal(item any) error {
 	ct := strings.ToLower(r.resp.Header.Get("content-type"))
 
+	// TODO: remove debug logging
+	fmt.Printf("DEBUG raw response body: %s\n", r.body)
+
 	if sb, ok := item.(*strings.Builder); ok {
 		_, err := sb.Write(r.body)
 		return err

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -147,7 +147,7 @@ const (
 
 	pathIndustries        = "/industries"
 	pathEnrichmentProfile = "/enrichment/profile"
-  
+
 	pathResolutionLinks = "/accounts/%s/resolution-links"
 	pathResolutionLink  = "/accounts/%s/resolution-links/%s"
 )

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -31,6 +31,8 @@ const (
 	PaymentMethodType_ApplePay           PaymentMethodType = "apple-pay"
 	PaymentMethodType_PushToCard         PaymentMethodType = "push-to-card"
 	PaymentMethodType_PullFromCard       PaymentMethodType = "pull-from-card"
+	PaymentMethodType_PushToApplePay    PaymentMethodType = "push-to-apple-pay"
+	PaymentMethodType_PullFromApplePay  PaymentMethodType = "pull-from-apple-pay"
 	PaymentMethodType_CardPresentPayment PaymentMethodType = "card-present-payment"
 	PaymentMethodType_InstantBankCredit  PaymentMethodType = "instant-bank-credit" // #nosec G101
 )

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -31,8 +31,8 @@ const (
 	PaymentMethodType_ApplePay           PaymentMethodType = "apple-pay"
 	PaymentMethodType_PushToCard         PaymentMethodType = "push-to-card"
 	PaymentMethodType_PullFromCard       PaymentMethodType = "pull-from-card"
-	PaymentMethodType_PushToApplePay    PaymentMethodType = "push-to-apple-pay"
-	PaymentMethodType_PullFromApplePay  PaymentMethodType = "pull-from-apple-pay"
+	PaymentMethodType_PushToApplePay     PaymentMethodType = "push-to-apple-pay"
+	PaymentMethodType_PullFromApplePay   PaymentMethodType = "pull-from-apple-pay"
 	PaymentMethodType_CardPresentPayment PaymentMethodType = "card-present-payment"
 	PaymentMethodType_InstantBankCredit  PaymentMethodType = "instant-bank-credit" // #nosec G101
 )


### PR DESCRIPTION
## Summary
- Add `PaymentMethodType_PushToApplePay` and `PaymentMethodType_PullFromApplePay` constants

## Context
New payment method type constants for Apple Pay push/pull, matching the API spec additions.

## Test plan
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)