### PR TITLE
feat(issuing): return issued card body from update issued card endpoint

### DIFF
--- a/examples/card_issuing/issuing_test.go
+++ b/examples/card_issuing/issuing_test.go
@@ -71,5 +71,6 @@ func closeIssuedCard(ctx context.Context, mc *moov.Client, accountID, cardID str
 	update := moov.UpdateIssuedCard{
 		State: &closed,
 	}
-	return mc.UpdateIssuedCard(ctx, accountID, cardID, update)
+	_, err := mc.UpdateIssuedCard(ctx, accountID, cardID, update)
+	return err
 }

--- a/pkg/moov/card_issuing_api.go
+++ b/pkg/moov/card_issuing_api.go
@@ -47,16 +47,16 @@ func (c Client) GetIssuedCard(ctx context.Context, accountID string, cardID stri
 
 // UpdateIssuedCard updates a specified issued card for the given account
 // https://docs.moov.io/api/money-movement/issuing/update/
-func (c Client) UpdateIssuedCard(ctx context.Context, accountID string, cardID string, update UpdateIssuedCard) error {
+func (c Client) UpdateIssuedCard(ctx context.Context, accountID string, cardID string, update UpdateIssuedCard) (*IssuedCard, error) {
 	httpResp, err := c.CallHttp(ctx,
 		Endpoint(http.MethodPatch, pathIssuedCard, accountID, cardID),
 		AcceptJson(),
 		JsonBody(update))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return CompletedNilOrError(httpResp)
+	return CompletedObjectOrError[IssuedCard](httpResp)
 }
 
 // ListIssuedCardAuthorizations retrieves all issued card authorizations for the given account

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -163,11 +163,6 @@ func Test_CardIssuing(t *testing.T) {
 	})
 	NoResponseError(t, err)
 	require.NotNil(t, card)
-
-	// get issued card
-	card, err = mc.GetIssuedCard(BgCtx(), MERCHANT_ID, created.IssuedCardID)
-	NoResponseError(t, err)
-	require.NotNil(t, card)
 	require.Equal(t, created.IssuedCardID, card.IssuedCardID)
 	require.Equal(t, string(closed), string(card.State))
 

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -158,13 +158,14 @@ func Test_CardIssuing(t *testing.T) {
 
 	// update issued card
 	closed := moov.UpdateIssuedCardState_Closed
-	err = mc.UpdateIssuedCard(BgCtx(), MERCHANT_ID, created.IssuedCardID, moov.UpdateIssuedCard{
+	card, err := mc.UpdateIssuedCard(BgCtx(), MERCHANT_ID, created.IssuedCardID, moov.UpdateIssuedCard{
 		State: &closed,
 	})
 	NoResponseError(t, err)
+	require.NotNil(t, card)
 
 	// get issued card
-	card, err := mc.GetIssuedCard(BgCtx(), MERCHANT_ID, created.IssuedCardID)
+	card, err = mc.GetIssuedCard(BgCtx(), MERCHANT_ID, created.IssuedCardID)
 	NoResponseError(t, err)
 	require.NotNil(t, card)
 	require.Equal(t, created.IssuedCardID, card.IssuedCardID)
@@ -194,7 +195,8 @@ func closeIssuedCard(ctx context.Context, mc *moov.Client, accountID, cardID str
 		update := moov.UpdateIssuedCard{
 			State: &closed,
 		}
-		return mc.UpdateIssuedCard(ctx, accountID, cardID, update)
+		_, err := mc.UpdateIssuedCard(ctx, accountID, cardID, update)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Modified updateIssuedCard issuing endpoint to return the updated issued card body with a 200 response code.

This was changed from returning a 204 response code with no content.