### PR TITLE
fix: clean up existing links before tests to avoid conflict

### DIFF
--- a/pkg/moov/resolutionlinks_models.go
+++ b/pkg/moov/resolutionlinks_models.go
@@ -12,6 +12,7 @@ type ResolutionLinkResponse struct {
 	DisabledOn         *time.Time `json:"disabledOn,omitempty"`
 	Recipient          string     `json:"recipient"`
 	URL                string     `json:"url"`
+	Status             string     `json:"status"`
 }
 
 type CreateResolutionLinkRequest struct {

--- a/pkg/moov/resolutionlinks_test.go
+++ b/pkg/moov/resolutionlinks_test.go
@@ -10,6 +10,15 @@ import (
 func Test_ResolutionLinks(t *testing.T) {
 	mc := NewTestClient(t)
 
+	cleanupExisting, err := mc.ListResolutionLinks(BgCtx(), MERCHANT_ID)
+	if err == nil {
+		for _, link := range cleanupExisting {
+			if link.Recipient == "noreply@moov.io" {
+				require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, link.ResolutionLinkCode))
+			}
+		}
+	}
+
 	var resolutionLinkCode string
 
 	t.Run("create resolution link", func(t *testing.T) {

--- a/pkg/moov/resolutionlinks_test.go
+++ b/pkg/moov/resolutionlinks_test.go
@@ -13,9 +13,7 @@ func Test_ResolutionLinks(t *testing.T) {
 	cleanupExisting, err := mc.ListResolutionLinks(BgCtx(), MERCHANT_ID)
 	if err == nil {
 		for _, link := range cleanupExisting {
-			if link.Recipient == "noreply@moov.io" {
-				require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, link.ResolutionLinkCode))
-			}
+			require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, link.ResolutionLinkCode))
 		}
 	}
 

--- a/pkg/moov/resolutionlinks_test.go
+++ b/pkg/moov/resolutionlinks_test.go
@@ -17,10 +17,6 @@ func Test_ResolutionLinks(t *testing.T) {
 		}
 	}
 
-	t.Run("delete duplicate resolution link", func(t *testing.T) {
-		require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, "pXpUz5PZbH"))
-	})
-
 	var resolutionLinkCode string
 
 	t.Run("create resolution link", func(t *testing.T) {

--- a/pkg/moov/resolutionlinks_test.go
+++ b/pkg/moov/resolutionlinks_test.go
@@ -17,6 +17,10 @@ func Test_ResolutionLinks(t *testing.T) {
 		}
 	}
 
+	t.Run("delete duplicate resolution link", func(t *testing.T) {
+		require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, "pXpUz5PZbH"))
+	})
+
 	var resolutionLinkCode string
 
 	t.Run("create resolution link", func(t *testing.T) {

--- a/pkg/moov/resolutionlinks_test.go
+++ b/pkg/moov/resolutionlinks_test.go
@@ -10,16 +10,14 @@ import (
 func Test_ResolutionLinks(t *testing.T) {
 	mc := NewTestClient(t)
 
-	cleanupExisting, err := mc.ListResolutionLinks(BgCtx(), MERCHANT_ID)
-	if err == nil {
-		for _, link := range cleanupExisting {
-			require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, link.ResolutionLinkCode))
-		}
-	}
-
 	var resolutionLinkCode string
 
 	t.Run("create resolution link", func(t *testing.T) {
+		cleanupExisting, err := mc.ListResolutionLinks(BgCtx(), MERCHANT_ID)
+		for _, link := range cleanupExisting {
+			require.NoError(t, mc.DeleteResolutionLink(BgCtx(), MERCHANT_ID, link.ResolutionLinkCode))
+		}
+
 		createReq := moov.CreateResolutionLinkRequest{
 			Recipient: moov.Recipient{
 				Email: "noreply@moov.io",


### PR DESCRIPTION
Fixes Test_ResolutionLinks failure. Resolution Links create returns a 409 status conflict when an account already has a resolution link created.