### PR TITLE
fix(invoices): fix json tags to deserialize invoicePayments

### DIFF
--- a/pkg/moov/invoice_models.go
+++ b/pkg/moov/invoice_models.go
@@ -20,7 +20,7 @@ type Invoice struct {
 	RefundedAmount      AmountDecimal    `json:"refundedAmount"`
 	DisputedAmount      AmountDecimal    `json:"disputedAmount"`
 	PaymentLinkCode     string           `json:"paymentLinkCode"`
-	InvoicePayments     []InvoicePayment `json:"invoicePayments,omitempty"`
+	Payments            []InvoicePayment `json:"invoicePayments,omitempty"`
 	CreatedOn           time.Time        `json:"createdOn"`
 	InvoiceDate         *time.Time       `json:"invoiceDate"`
 	DueDate             *time.Time       `json:"dueDate"`

--- a/pkg/moov/invoice_models.go
+++ b/pkg/moov/invoice_models.go
@@ -20,7 +20,7 @@ type Invoice struct {
 	RefundedAmount      AmountDecimal    `json:"refundedAmount"`
 	DisputedAmount      AmountDecimal    `json:"disputedAmount"`
 	PaymentLinkCode     string           `json:"paymentLinkCode"`
-	Payments            []InvoicePayment `json:"payments"`
+	InvoicePayments     []InvoicePayment `json:"invoicePayments,omitempty"`
 	CreatedOn           time.Time        `json:"createdOn"`
 	InvoiceDate         *time.Time       `json:"invoiceDate"`
 	DueDate             *time.Time       `json:"dueDate"`

--- a/pkg/moov/invoice_test.go
+++ b/pkg/moov/invoice_test.go
@@ -92,6 +92,12 @@ func Test_Invoice_CreateUpdateGet(t *testing.T) {
 	require.Len(t, payments, 1)
 	latestPayment := payments[0]
 	require.Equal(t, *createdPayment, latestPayment)
+
+	// Re-fetch the invoice and verify InvoicePayments
+	paidInvoice, err := mc.GetInvoice(ctx, accountID, createdInvoice.InvoiceID)
+	require.NoError(t, err)
+	require.Len(t, paidInvoice.InvoicePayments, 1)
+	require.Equal(t, createdPayment.InvoicePaymentID, paidInvoice.InvoicePayments[0].InvoicePaymentID)
 }
 
 func Test_Invoice_Delete(t *testing.T) {

--- a/pkg/moov/invoice_test.go
+++ b/pkg/moov/invoice_test.go
@@ -96,8 +96,8 @@ func Test_Invoice_CreateUpdateGet(t *testing.T) {
 	// Re-fetch the invoice and verify InvoicePayments
 	paidInvoice, err := mc.GetInvoice(ctx, accountID, createdInvoice.InvoiceID)
 	require.NoError(t, err)
-	require.Len(t, paidInvoice.InvoicePayments, 1)
-	require.Equal(t, createdPayment.InvoicePaymentID, paidInvoice.InvoicePayments[0].InvoicePaymentID)
+	require.Len(t, paidInvoice.Payments, 1)
+	require.Equal(t, createdPayment.InvoicePaymentID, paidInvoice.Payments[0].InvoicePaymentID)
 }
 
 func Test_Invoice_Delete(t *testing.T) {


### PR DESCRIPTION
Fix json serialization of `Invoice.Payments` field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the JSON field name used for `Invoice.Payments`, which can affect any consumers relying on the previous `payments` key when marshaling/unmarshaling.
> 
> **Overview**
> Fixes `Invoice.Payments` JSON tagging to use `invoicePayments` (with `omitempty`) so invoice payment data returned from the API deserializes correctly.
> 
> Adds a test assertion that after creating and listing an invoice payment, re-fetching the invoice populates `Payments` with the created `InvoicePaymentID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a896689f8a9567111d458edd8345f938aec7fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->