### PR TITLE
feat(moov): add wire-credit payment method

### DIFF
--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -35,6 +35,7 @@ const (
 	PaymentMethodType_PullFromApplePay   PaymentMethodType = "pull-from-apple-pay"
 	PaymentMethodType_CardPresentPayment PaymentMethodType = "card-present-payment"
 	PaymentMethodType_InstantBankCredit  PaymentMethodType = "instant-bank-credit" // #nosec G101
+	PaymentMethodType_WireCredit         PaymentMethodType = "wire-credit"
 )
 
 // WalletPaymentMethod A Moov wallet to store funds for transfers.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new `PaymentMethodType` enum value with no behavioral logic changes or data processing updates.
> 
> **Overview**
> Adds support for representing wire credit rails by introducing a new `PaymentMethodType_WireCredit` constant (`"wire-credit"`) in `payment_method_models.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb94db4899ce53a29b4470cde0523b144aac707f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->