### PR TITLE
fix: add status to BankAccountCreated

### DIFF
--- a/pkg/mhooks/event_test.go
+++ b/pkg/mhooks/event_test.go
@@ -113,3 +113,20 @@ func TestParseEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestBankAccountCreated(t *testing.T) {
+	ba := BankAccountCreated{
+		BankAccountID: uuid.NewString(),
+		AccountID:     uuid.NewString(),
+		Status:        moov.BankAccountStatus_New,
+	}
+
+	event := Event{
+		EventType:          EventTypeBankAccountCreated,
+		bankAccountCreated: &ba,
+	}
+
+	got, err := event.BankAccountCreated()
+	require.NoError(t, err)
+	require.Equal(t, ba, *got)
+}

--- a/pkg/mhooks/event_type.go
+++ b/pkg/mhooks/event_type.go
@@ -77,6 +77,8 @@ type BankAccountCreated struct {
 	BankAccountID string `json:"bankAccountID"`
 	// ID of the account where the bank account was created
 	AccountID string `json:"accountID"`
+	// Status of the bank account
+	Status moov.BankAccountStatus `json:"status"`
 }
 
 type BankAccountDeleted struct {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small schema extension to a webhook event payload plus a unit test; primary risk is minor downstream impact for consumers who assume the old `BankAccountCreated` JSON shape.
> 
> **Overview**
> `BankAccountCreated` webhook payloads now include a `status` field (`moov.BankAccountStatus`) to match other bank-account event shapes.
> 
> Adds a small unit test (`TestBankAccountCreated`) to verify `Event.BankAccountCreated()` returns the hydrated payload including `Status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2453d649c35295b4e1c27fabb5e3e533c9bec6de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->