### PR TITLE
Add `Nullable[T]` fields to `PatchAccount` under versioned package `mv2604`

### DIFF
--- a/pkg/moov/account_api.go
+++ b/pkg/moov/account_api.go
@@ -44,7 +44,7 @@ func (ac *AccountClient[T, V]) Create(ctx context.Context, client Client, accoun
 // Get returns an account based on accountID.
 func (ac AccountClient[T, V]) Get(ctx context.Context, client Client, accountID string) (*V, error) {
 	resp, err := client.CallHttp(ctx,
-		Endpoint(http.MethodGet, pathAccount, accountID),
+		Endpoint(http.MethodGet, PathAccount, accountID),
 		MoovVersion(ac.Version),
 		AcceptJson())
 	if err != nil {
@@ -57,7 +57,7 @@ func (ac AccountClient[T, V]) Get(ctx context.Context, client Client, accountID 
 // Patch updates an account.
 func (ac AccountClient[T, V]) Patch(ctx context.Context, client Client, accountID string, account PatchAccount) (*V, error) {
 	resp, err := client.CallHttp(ctx,
-		Endpoint(http.MethodPatch, pathAccount, accountID),
+		Endpoint(http.MethodPatch, PathAccount, accountID),
 		MoovVersion(ac.Version),
 		AcceptJson(),
 		JsonBody(account))
@@ -98,7 +98,7 @@ func (ac AccountClient[T, V]) ListConnected(ctx context.Context, client Client, 
 // This also means you'll only have read-only access to the account going forward for reporting purposes.
 func (ac AccountClient[T, V]) Disconnect(ctx context.Context, client Client, accountID string) error {
 	resp, err := client.CallHttp(ctx,
-		Endpoint(http.MethodDelete, pathAccount, accountID),
+		Endpoint(http.MethodDelete, PathAccount, accountID),
 		MoovVersion(ac.Version),
 		AcceptJson())
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *Client) CreateAccount(ctx context.Context, account CreateAccount) (crea
 // GetAccount returns an account based on accountID.
 func (c Client) GetAccount(ctx context.Context, accountID string) (*Account, error) {
 	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodGet, pathAccount, accountID),
+		Endpoint(http.MethodGet, PathAccount, accountID),
 		AcceptJson())
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (c Client) GetAccount(ctx context.Context, accountID string) (*Account, err
 // UpdateAccount updates an account.
 func (c Client) UpdateAccount(ctx context.Context, account Account) (*Account, error) {
 	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodPatch, pathAccount, account.AccountID),
+		Endpoint(http.MethodPatch, PathAccount, account.AccountID),
 		AcceptJson(),
 		JsonBody(account))
 	if err != nil {
@@ -172,7 +172,7 @@ func (c Client) UpdateAccount(ctx context.Context, account Account) (*Account, e
 // PatchAccount updates an account.
 func (c Client) PatchAccount(ctx context.Context, accountID string, account PatchAccount) (*Account, error) {
 	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodPatch, pathAccount, accountID),
+		Endpoint(http.MethodPatch, PathAccount, accountID),
 		AcceptJson(),
 		JsonBody(account))
 	if err != nil {
@@ -265,7 +265,7 @@ func (c Client) ListAccounts(ctx context.Context, opts ...ListAccountFilter) ([]
 // Only use for Preversioned API calls. Use mvxxxx.Accounts.Disconnect(...) instead.
 func (c Client) DisconnectAccount(ctx context.Context, accountID string) error {
 	resp, err := c.CallHttp(ctx,
-		Endpoint(http.MethodDelete, pathAccount, accountID),
+		Endpoint(http.MethodDelete, PathAccount, accountID),
 		AcceptJson())
 	if err != nil {
 		return err

--- a/pkg/moov/account_test.go
+++ b/pkg/moov/account_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/moovfinancial/moov-go/internal/testtools"
 	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/moovfinancial/moov-go/pkg/mv2507"
+	"github.com/moovfinancial/moov-go/pkg/mv2604"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -230,6 +232,67 @@ func TestPatchIndividualAccount_V2507(t *testing.T) {
 	require.True(t, result.Profile.Individual.BirthDateProvided)
 }
 
+func TestPatchIndividualAccount_V2604(t *testing.T) {
+	mc := NewTestClient(t)
+	ctx := BgCtx()
+
+	account, _, err := mc.CreateAccount(ctx, createTestIndividualAccount())
+	NoResponseError(t, err)
+	require.NotNil(t, account)
+
+	patchAccount := mv2604.PatchAccount{
+		Profile: mv2604.PatchProfile{
+			Individual: moov.Set(mv2604.PatchIndividualProfile{
+				Name: moov.Name{
+					FirstName: "John",
+					LastName:  "Doe",
+				},
+				Phone: moov.Set(moov.Phone{
+					Number:      "555-555-6666",
+					CountryCode: "1",
+				}),
+				Email: "john.doe@moov.io",
+				Address: moov.Set(moov.Address{
+					AddressLine1:    "123 Main St",
+					City:            "Moov City",
+					StateOrProvince: "CA",
+					PostalCode:      "12345",
+					Country:         "US",
+				}),
+				BirthDate: moov.Set(moov.Date{
+					Year:  1990,
+					Month: 1,
+					Day:   1,
+				}),
+				GovernmentID: moov.Set(moov.GovernmentID{
+					SSN: &moov.SSN{
+						Full: "123-45-6789",
+					},
+				}),
+			}),
+		},
+	}
+
+	result, err := mv2604.Accounts.Patch(context.Background(), *mc, account.AccountID, patchAccount)
+	NoResponseError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Profile.Individual)
+	require.Nil(t, result.Profile.Business)
+	require.NotNil(t, result.Profile.Individual.Phone)
+	require.Equal(t, "John", result.Profile.Individual.Name.FirstName)
+	require.Equal(t, "Doe", result.Profile.Individual.Name.LastName)
+	require.Equal(t, "5555556666", result.Profile.Individual.Phone.Number)
+	require.Equal(t, "1", result.Profile.Individual.Phone.CountryCode)
+	require.Equal(t, "john.doe@moov.io", result.Profile.Individual.Email)
+	require.Equal(t, "123 Main St", result.Profile.Individual.Address.AddressLine1)
+	require.Equal(t, "Moov City", result.Profile.Individual.Address.City)
+	require.Equal(t, "CA", result.Profile.Individual.Address.StateOrProvince)
+	require.Equal(t, "12345", result.Profile.Individual.Address.PostalCode)
+	require.Equal(t, "US", result.Profile.Individual.Address.Country)
+	require.True(t, result.Profile.Individual.GovernmentIDProvided)
+	require.True(t, result.Profile.Individual.BirthDateProvided)
+}
+
 func TestPatchBusinessAccount(t *testing.T) {
 	mc := NewTestClient(t)
 	ctx := BgCtx()
@@ -364,6 +427,111 @@ func TestPatchBusinessAccount(t *testing.T) {
 		NoResponseError(t, err)
 		require.NotNil(t, result)
 		require.Contains(t, result.Metadata, "key1")
+	})
+}
+
+func TestPatchBusinessAccount_V2604(t *testing.T) {
+	mc := NewTestClient(t)
+	ctx := BgCtx()
+
+	account, _, err := mc.CreateAccount(ctx, createTestBusinessAccount())
+	NoResponseError(t, err)
+	require.NotNil(t, account)
+
+	t.Run("foreignID, customer support and account settings", func(t *testing.T) {
+		foreignID := uuid.NewString()
+		patchAccount := mv2604.PatchAccount{
+			ForeignID: foreignID,
+			TermsOfService: moov.Set(mv2604.TermsOfServicePayload{
+				Manual: moov.Set(moov.TermsOfServiceManual{
+					AcceptanceIP:        "127.0.0.1",
+					AcceptanceDomain:    "moov.io",
+					AcceptanceUserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+					AcceptanceDate:      time.Now(),
+				}),
+			}),
+			CustomerSupport: moov.Set(mv2604.CustomerSupport{
+				Email: "test@moov.io",
+				Phone: moov.Set(moov.Phone{
+					Number:      "555-555-5555",
+					CountryCode: "1",
+				}),
+				Website: "https://moov.io",
+				Address: moov.Set(moov.Address{
+					AddressLine1:    "123 Main St",
+					City:            "Moov City",
+					StateOrProvince: "CA",
+					PostalCode:      "12345",
+					Country:         "US",
+				}),
+			}),
+			AccountSettings: moov.Set(mv2604.AccountSettings{
+				CardPayment: moov.Set(moov.CardPaymentSettings{
+					StatementDescriptor: "Moov",
+				}),
+				AchPayment: moov.Set(moov.AchPaymentSettings{
+					CompanyName: "Moov",
+				}),
+			}),
+		}
+
+		validate := func(result *moov.Account) {
+			require.NotNil(t, result)
+			require.NotNil(t, result.TermsOfService)
+			require.NotNil(t, result.CustomerSupport)
+			require.NotNil(t, result.CustomerSupport.Phone)
+			require.NotNil(t, result.CustomerSupport.Address)
+			require.NotNil(t, result.Settings)
+			require.NotNil(t, result.Settings.CardPayment)
+			require.NotNil(t, result.Settings.AchPayment)
+			require.Equal(t, foreignID, result.ForeignID)
+			require.Equal(t, "127.0.0.1", result.TermsOfService.AcceptedIP)
+			require.WithinDuration(t, time.Now(), result.TermsOfService.AcceptedDate, 5*time.Second)
+			require.Equal(t, "5555555555", result.CustomerSupport.Phone.Number)
+			require.Equal(t, "1", result.CustomerSupport.Phone.CountryCode)
+			require.Equal(t, "https://moov.io", result.CustomerSupport.Website)
+			require.Equal(t, "123 Main St", result.CustomerSupport.Address.AddressLine1)
+			require.Equal(t, "Moov City", result.CustomerSupport.Address.City)
+			require.Equal(t, "CA", result.CustomerSupport.Address.StateOrProvince)
+			require.Equal(t, "12345", result.CustomerSupport.Address.PostalCode)
+			require.Equal(t, "US", result.CustomerSupport.Address.Country)
+			require.Equal(t, "Moov", result.Settings.CardPayment.StatementDescriptor)
+			require.Equal(t, "Moov", result.Settings.AchPayment.CompanyName)
+			require.Equal(t, "electronics-appliances", result.Profile.Business.Industry)
+		}
+
+		result, err := mv2604.Accounts.Patch(context.Background(), *mc, account.AccountID, patchAccount)
+		NoResponseError(t, err)
+		validate(result)
+
+		result, err = mc.GetAccount(ctx, account.AccountID)
+		NoResponseError(t, err)
+		validate(result)
+	})
+
+	t.Run("null out AccountSettings and CustomerSupport fields", func(t *testing.T) {
+		// Currently, the accounts backend does not support nulling out the TermsOfService field.
+		// Uncomment the fields below when support is added.
+		patchAccount := mv2604.PatchAccount{
+			// TermsOfService:  moov.SetNull[mv2604.TermsOfServicePayload](),
+			CustomerSupport: moov.SetNull[mv2604.CustomerSupport](),
+			AccountSettings: moov.SetNull[mv2604.AccountSettings](),
+		}
+
+		validate := func(result *moov.Account) {
+			require.NotNil(t, result)
+			// require.Nil(t, result.TermsOfService)
+			require.Nil(t, result.CustomerSupport)
+			require.Nil(t, result.Settings)
+		}
+
+		result, err := mv2604.Accounts.Patch(context.Background(), *mc, account.AccountID, patchAccount)
+		NoResponseError(t, err)
+		validate(result)
+
+		result, err = mc.GetAccount(ctx, account.AccountID)
+		NoResponseError(t, err)
+		validate(result)
 	})
 }
 

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -7,7 +7,7 @@ const (
 	pathOAuth2Revoke = "/oauth2/revoke"
 
 	pathAccounts          = "/accounts"
-	pathAccount           = "/accounts/%s"
+	PathAccount           = "/accounts/%s"
 	pathAccountsConnected = "/accounts/%s/connected-accounts"
 
 	pathApplications    = "/applications"

--- a/pkg/mv2604/account_models.go
+++ b/pkg/mv2604/account_models.go
@@ -1,0 +1,86 @@
+package mv2604
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type AccountClient[T any, V any] struct {
+	moov.AccountClient[T, V]
+}
+
+var Accounts = AccountClient[PatchAccount, moov.Account]{AccountClient: moov.AccountClient[PatchAccount, moov.Account]{Version: moov.Version2026_04}}
+
+type PatchAccount struct {
+	ForeignID       string                                `json:"foreignID,omitempty"`
+	Profile         PatchProfile                          `json:"profile"`
+	Metadata        *moov.Nullable[map[string]string]     `json:"metadata,omitempty"`
+	TermsOfService  *moov.Nullable[TermsOfServicePayload] `json:"termsOfService,omitempty"`
+	CustomerSupport *moov.Nullable[CustomerSupport]       `json:"customerSupport,omitempty"`
+	AccountSettings *moov.Nullable[AccountSettings]       `json:"settings,omitempty"`
+}
+
+func (ac AccountClient[T, V]) Patch(ctx context.Context, client moov.Client, accountID string, account PatchAccount) (*V, error) {
+	resp, err := client.CallHttp(ctx,
+		moov.Endpoint(http.MethodPatch, moov.PathAccount, accountID),
+		moov.MoovVersion(ac.Version),
+		moov.AcceptJson(),
+		moov.JsonBody(account))
+	if err != nil {
+		return nil, err
+	}
+
+	return moov.CompletedObjectOrError[V](resp)
+}
+
+type PatchProfile struct {
+	Individual *moov.Nullable[PatchIndividualProfile] `json:"individual,omitempty"`
+	Business   *moov.Nullable[PatchBusinessProfile]   `json:"business,omitempty"`
+}
+
+type PatchIndividualProfile struct {
+	Name         moov.Name                         `json:"name"`
+	Phone        *moov.Nullable[moov.Phone]        `json:"phone,omitempty"`
+	Email        string                            `json:"email"`
+	Address      *moov.Nullable[moov.Address]      `json:"address,omitempty"`
+	BirthDate    *moov.Nullable[moov.Date]         `json:"birthDate,omitempty"`
+	GovernmentID *moov.Nullable[moov.GovernmentID] `json:"governmentID,omitempty"`
+}
+
+type PatchBusinessProfile struct {
+	Name             string                                `json:"legalBusinessName,omitempty"`
+	DBA              string                                `json:"doingBusinessAs,omitempty"`
+	Type             *moov.Nullable[moov.BusinessType]     `json:"businessType,omitempty"`
+	Address          *moov.Nullable[moov.Address]          `json:"address,omitempty"`
+	Phone            *moov.Nullable[moov.Phone]            `json:"phone,omitempty"`
+	Email            string                                `json:"email,omitempty"`
+	Website          string                                `json:"website,omitempty"`
+	Description      string                                `json:"description,omitempty"`
+	OwnersProvided   bool                                  `json:"ownersProvided,omitempty"`
+	Industry         string                                `json:"industry,omitempty"`
+	IndustryCodes    *moov.Nullable[moov.IndustryCodes]    `json:"industryCodes,omitempty"`
+	PrimaryRegulator *moov.Nullable[moov.PrimaryRegulator] `json:"primaryRegulator,omitempty"`
+	TaxID            *moov.Nullable[moov.TaxID]            `json:"taxID"`
+}
+
+type TermsOfServicePayload struct {
+	Token  string                                    `json:"token,omitempty"`
+	Manual *moov.Nullable[moov.TermsOfServiceManual] `json:"manual,omitempty"`
+}
+
+// CustomerSupport User-provided information that can be displayed on credit card transactions for customers to use when contacting a customer support team. This data is only allowed on a business account.
+type CustomerSupport struct {
+	Phone *moov.Nullable[moov.Phone] `json:"phone,omitempty"`
+	// Email address.
+	Email   string                       `json:"email,omitempty"`
+	Address *moov.Nullable[moov.Address] `json:"address,omitempty"`
+	Website string                       `json:"website,omitempty"`
+}
+
+// AccountSettings User provided settings to manage an account.
+type AccountSettings struct {
+	CardPayment *moov.Nullable[moov.CardPaymentSettings] `json:"cardPayment,omitempty"`
+	AchPayment  *moov.Nullable[moov.AchPaymentSettings]  `json:"achPayment,omitempty"`
+}


### PR DESCRIPTION
Reference: https://github.com/moovfinancial/moov-go/pull/320

Update `PatchAccount` optional fields to be `Nullable[T]` in order to use `SetNull(..)` to unset optional fields, i.e. `null` in JSON request body.

Since we don't want to break existing customer integrations with the non-versioned `PatchAccount`, JJ recommended placing it under a versioned package, in this case `mv2604`.