### PR TITLE
feat(mv2604): support nulling sweep config fields via Nullable[T]

### DIFF
--- a/examples/sweeps/sweep_test.go
+++ b/examples/sweeps/sweep_test.go
@@ -13,7 +13,7 @@ import (
 func TestSweepConfigsEndpoints(t *testing.T) {
 	mc, err := moov.NewClient()
 	require.NoError(t, err)
-	sweepServiceV2604 := mv2604.NewSweepService(mc)
+	sweepClientV2604 := mv2604.NewSweepClient(mc)
 
 	var (
 		ctx = context.Background()
@@ -64,7 +64,7 @@ func TestSweepConfigsEndpoints(t *testing.T) {
 	t.Logf("Got sweep config by ID: %+v", sweepConfig)
 
 	t.Run("v2604.UpdateSweepConfig unsets the statement descriptor", func(t *testing.T) {
-		sweepConfig, err = sweepServiceV2604.UpdateSweepConfig(ctx, accountID, sweepConfig.SweepConfigID, mv2604.UpdateSweepConfig{
+		sweepConfig, err = sweepClientV2604.UpdateSweepConfig(ctx, accountID, sweepConfig.SweepConfigID, mv2604.UpdateSweepConfig{
 			StatementDescriptor: moov.SetNull[string](),
 		})
 		require.NoError(t, err)

--- a/examples/sweeps/sweep_test.go
+++ b/examples/sweeps/sweep_test.go
@@ -7,11 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2604"
 )
 
 func TestSweepConfigsEndpoints(t *testing.T) {
 	mc, err := moov.NewClient()
 	require.NoError(t, err)
+	sweepServiceV2604 := mv2604.NewSweepService(mc)
 
 	var (
 		ctx = context.Background()
@@ -60,6 +62,20 @@ func TestSweepConfigsEndpoints(t *testing.T) {
 	sweepConfig, err = mc.GetSweepConfig(ctx, accountID, sweepConfig.SweepConfigID)
 	require.NoError(t, err)
 	t.Logf("Got sweep config by ID: %+v", sweepConfig)
+
+	t.Run("v2604.UpdateSweepConfig unsets the statement descriptor", func(t *testing.T) {
+		sweepConfig, err = sweepServiceV2604.UpdateSweepConfig(ctx, accountID, sweepConfig.SweepConfigID, mv2604.UpdateSweepConfig{
+			StatementDescriptor: moov.SetNull[string](),
+		})
+		require.NoError(t, err)
+		require.Nil(t, sweepConfig.StatementDescriptor)
+		t.Logf("unset statement descriptor in sweep config: %+v", sweepConfig)
+
+		sweepConfig, err = mc.GetSweepConfig(ctx, accountID, sweepConfig.SweepConfigID)
+		require.NoError(t, err)
+		require.Nil(t, sweepConfig.StatementDescriptor)
+		t.Logf("got sweep config with unset statement descriptor: %+v", sweepConfig)
+	})
 }
 
 func TestSweepEndpoints(t *testing.T) {

--- a/pkg/moov/sweep_api.go
+++ b/pkg/moov/sweep_api.go
@@ -130,3 +130,24 @@ func (c Client) GetSweep(ctx context.Context, accountID string, walletID string,
 
 	return CompletedObjectOrError[Sweep](resp)
 }
+
+/* Exported functions used only for making client calls in the versioned packages (e.g. mv2604) */
+
+func UpdateSweepConfigGeneric[T any](ctx context.Context, client *Client, version Version, accountID string, sweepConfigID string, update T) (*SweepConfig, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
+
+	resp, err := client.CallHttp(
+		ctx,
+		Endpoint(http.MethodPatch, pathSweepConfig, accountID, sweepConfigID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(update),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("updating sweep config: %w", err)
+	}
+
+	return CompletedObjectOrError[SweepConfig](resp)
+}

--- a/pkg/mv2604/sweep_api.go
+++ b/pkg/mv2604/sweep_api.go
@@ -6,15 +6,15 @@ import (
 	"github.com/moovfinancial/moov-go/pkg/moov"
 )
 
-type SweepService struct {
+type SweepClient struct {
 	client *moov.Client
 }
 
-func NewSweepService(client *moov.Client) SweepService {
-	return SweepService{client: client}
+func NewSweepClient(client *moov.Client) SweepClient {
+	return SweepClient{client: client}
 }
 
-func (s SweepService) UpdateSweepConfig(ctx context.Context, accountID, sweepConfigID string, update UpdateSweepConfig) (*moov.SweepConfig, error) {
+func (s SweepClient) UpdateSweepConfig(ctx context.Context, accountID, sweepConfigID string, update UpdateSweepConfig) (*moov.SweepConfig, error) {
 	return moov.UpdateSweepConfigGeneric(ctx, s.client, moov.Version2026_04, accountID, sweepConfigID, update)
 }
 

--- a/pkg/mv2604/sweep_api.go
+++ b/pkg/mv2604/sweep_api.go
@@ -1,0 +1,26 @@
+package mv2604
+
+import (
+	"context"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type SweepService struct {
+	client *moov.Client
+}
+
+func NewSweepService(client *moov.Client) SweepService {
+	return SweepService{client: client}
+}
+
+func (s SweepService) UpdateSweepConfig(ctx context.Context, accountID, sweepConfigID string, update UpdateSweepConfig) (*moov.SweepConfig, error) {
+	return moov.UpdateSweepConfigGeneric(ctx, s.client, moov.Version2026_04, accountID, sweepConfigID, update)
+}
+
+type UpdateSweepConfig struct {
+	moov.UpdateSweepConfig
+
+	// An optional override of the default NACHA company entry description for sweep transfers.
+	StatementDescriptor *moov.Nullable[string] `json:"statementDescriptor,omitempty"`
+}


### PR DESCRIPTION
## Context

Updating ledger-owned PATCH endpoint models to support the new `Nullable[T]` type on optional fields, without breaking existing integrations to our unversioned PATCH endpoints.

## Changes

- `pkg/moov/sweep_api.go` — introduces `UpdateSweepConfigGeneric[T]` exported generic function for the `mvyymm` versioned packages to call with specific versioning.
- Adds a new versioned package `mv2604` to house versioned endpoint functions and models.
- `pkg/mv2604/sweep_api.go` — Adds `mv2604.SweepService.UpdateSweepConfig` which extends the base `moov.UpdateSweepConfig` with `Nullable[T]`-typed fields, allowing callers to explicitly null out sweep config values (e.g. clearing `statementDescriptor`)
- `examples/sweeps/sweep_test.go` — adds test demonstrating unset via `moov.SetNull[string]()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new versioned sweep update wrapper and a generic helper without changing existing unversioned sweep endpoints; main risk is incorrect versioning/JSON encoding for explicit nulls on `PATCH`.
> 
> **Overview**
> Adds a versioned sweeps API surface (`pkg/mv2604`) with `SweepService.UpdateSweepConfig` that targets `Version2026_04` and extends the update model to use `*moov.Nullable[string]` so callers can *explicitly unset* fields (serialize `null`) on `PATCH`.
> 
> Introduces `moov.UpdateSweepConfigGeneric[T]` to centralize the versioned `PATCH` call logic used by these `mvyymm` packages, and updates the sweeps example test to demonstrate clearing `statementDescriptor` via `moov.SetNull[string]()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a8a2b564484b19af8fbd40d59c09f8618199d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->