### PR TITLE
feat(mv2604): support nulling wallet fields via Nullable[T]

### DIFF
--- a/examples/ach/credit_external_bank/micro_deposits_test.go
+++ b/examples/ach/credit_external_bank/micro_deposits_test.go
@@ -83,8 +83,6 @@ func TestMicroDepositExample(t *testing.T) {
 
 	// Step 4: find moov-wallet payment method for the linked bank account
 
-	// When we have only one bank account linked, we can avoid checking that the
-	// payment method is for user's bank account and just use the first one.
 	var paymentMethods []moov.PaymentMethod
 	require.Eventually(t, func() bool {
 		paymentMethods, err = mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
@@ -93,10 +91,8 @@ func TestMicroDepositExample(t *testing.T) {
 		return len(paymentMethods) > 0
 	}, 10*time.Second, time.Second)
 
-	// We expect to have only one `moov-wallet` payment method on the connected account
-	require.Len(t, paymentMethods, 1)
-
-	sourcePaymentMethod := paymentMethods[0]
+	sourcePaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 5: configure destination payment method
 

--- a/examples/ach/debit_bank_account/micro_deposits_test.go
+++ b/examples/ach/debit_bank_account/micro_deposits_test.go
@@ -106,10 +106,9 @@ func TestMicroDepositExample(t *testing.T) {
 	paymentMethods, err = mc.ListPaymentMethods(ctx, destinationAccountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
 
-	require.Len(t, paymentMethods, 1)
-
 	// This is the destination payment method (Moov wallet)
-	destinationPaymentMethod := paymentMethods[0]
+	destinationPaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 6: create transfer
 	completedTransfer, _, err := mc.CreateTransfer(

--- a/examples/ach/debit_bank_account/plaid_processors_test.go
+++ b/examples/ach/debit_bank_account/plaid_processors_test.go
@@ -94,10 +94,10 @@ func TestPlaidProcessorExample(t *testing.T) {
 	// destination Moov wallet ("moov-wallet" payment method).
 	paymentMethods, err = mc.ListPaymentMethods(ctx, destinationAccountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
-	require.Len(t, paymentMethods, 1)
 
 	// This is the destination payment method (Moov wallet)
-	destinationPaymentMethod := paymentMethods[0]
+	destinationPaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 6: create transfer
 	completedTransfer, _, err := mc.CreateTransfer(

--- a/examples/bankaccounts/bank_account_instant_verification_test.go
+++ b/examples/bankaccounts/bank_account_instant_verification_test.go
@@ -95,10 +95,8 @@ func TestBankAccount_InstantVerificationExample(t *testing.T) {
 
 	// Step 4: find (push) payment methods for the linked bank account
 
-	sourceAccountID := "ebbf46c6-122a-4367-bc45-7dd555e1d3b9"
+	sourceAccountID := testtools.MERCHANT_ID
 
-	// When we have only one bank account linked, we can avoid checking that the
-	// payment method is for user's bank account and just use the first one.
 	var paymentMethods []moov.PaymentMethod
 	require.Eventually(t, func() bool {
 		paymentMethods, err = mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
@@ -107,10 +105,8 @@ func TestBankAccount_InstantVerificationExample(t *testing.T) {
 		return len(paymentMethods) > 0
 	}, 10*time.Second, time.Second)
 
-	// We expect to have only one `moov-wallet` payment method on the connected account
-	require.Len(t, paymentMethods, 1)
-
-	sourcePaymentMethod := paymentMethods[0]
+	sourcePaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 5: configure destination payment method
 

--- a/examples/debit_card_pull/debit_pull_test.go
+++ b/examples/debit_card_pull/debit_pull_test.go
@@ -74,10 +74,9 @@ func TestDebitPullWithRefund(t *testing.T) {
 	paymentMethods, err := mc.ListPaymentMethods(ctx, accountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
 
-	require.Len(t, paymentMethods, 1)
-
-	// This is the source payment method (Moov wallet)
-	destinationPaymentMethod := paymentMethods[0]
+	// This is the destination payment method (Moov wallet)
+	destinationPaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 6: create transfer
 	completedTransfer, _, err := mc.CreateTransfer(

--- a/examples/debit_card_push/debit_push_test.go
+++ b/examples/debit_card_push/debit_push_test.go
@@ -94,10 +94,9 @@ func TestVisaSandboxPush(t *testing.T) {
 	paymentMethods, err = mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
 
-	require.Len(t, paymentMethods, 1)
-
 	// This is the source payment method (Moov wallet)
-	sourcePaymentMethod := paymentMethods[0]
+	sourcePaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(paymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 6: create transfer
 	completedTransfer, _, err := mc.CreateTransfer(

--- a/examples/rtp/rtp_credit_ach_fallback_test.go
+++ b/examples/rtp/rtp_credit_ach_fallback_test.go
@@ -32,9 +32,9 @@ func TestRTPCreditACHFallbackExample(t *testing.T) {
 	// Step 2: Get the source wallet for our RTP transfer
 	sourcePaymentMethods, err := mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
-	require.Len(t, sourcePaymentMethods, 1)
 
-	sourcePaymentMethod := sourcePaymentMethods[0]
+	sourcePaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(sourcePaymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 3: Create account for the destination
 	account, _, err := mc.CreateAccount(ctx, moov.CreateAccount{

--- a/examples/rtp/rtp_credit_test.go
+++ b/examples/rtp/rtp_credit_test.go
@@ -38,9 +38,9 @@ func TestRTPCreditExample(t *testing.T) {
 	// Step 2: Get the source wallet for our RTP transfer
 	sourcePaymentMethods, err := mc.ListPaymentMethods(ctx, sourceAccountID, moov.WithPaymentMethodType("moov-wallet"))
 	require.NoError(t, err)
-	require.Len(t, sourcePaymentMethods, 1)
 
-	sourcePaymentMethod := sourcePaymentMethods[0]
+	sourcePaymentMethod, ok := testtools.FindMerchantWalletPaymentMethod(sourcePaymentMethods)
+	require.True(t, ok, "expected moov-wallet payment method for MERCHANT_WALLET_ID %s", testtools.MERCHANT_WALLET_ID)
 
 	// Step 3: Create account for the destination
 	account, _, err := mc.CreateAccount(ctx, moov.CreateAccount{

--- a/examples/wallets/wallet_test.go
+++ b/examples/wallets/wallet_test.go
@@ -96,6 +96,23 @@ func TestWalletEndpoints(t *testing.T) {
 		t.Logf("Created wallet: %+v", created)
 	}
 
+	t.Run("v2604.UpdateWallet sets the description and metadata", func(t *testing.T) {
+		updatedWallet, err := walletClientV2604.UpdateWallet(ctx, accountID, walletID, mv2604.UpdateWallet{
+			Description: moov.Set("new description"),
+			Metadata:    moov.Set(map[string]string{"foo": "baz"}),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "new description", updatedWallet.Description)
+		require.Equal(t, map[string]string{"foo": "baz"}, updatedWallet.Metadata)
+		t.Logf("set description and metadata in wallet: %+v", updatedWallet)
+
+		fetchedWallet, err := walletClientV2604.GetWallet(ctx, accountID, walletID)
+		require.NoError(t, err)
+		require.Equal(t, "new description", fetchedWallet.Description)
+		require.Equal(t, map[string]string{"foo": "baz"}, fetchedWallet.Metadata)
+		t.Logf("got wallet with set description and metadata: %+v", fetchedWallet)
+	})
+
 	t.Run("v2604.UpdateWallet unsets the description and metadata", func(t *testing.T) {
 		updatedWallet, err := walletClientV2604.UpdateWallet(ctx, accountID, walletID, mv2604.UpdateWallet{
 			Description: moov.SetNull[string](),

--- a/examples/wallets/wallet_test.go
+++ b/examples/wallets/wallet_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/moovfinancial/moov-go/internal/testtools"
 	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/moovfinancial/moov-go/pkg/mv2604"
 )
@@ -70,21 +71,33 @@ func TestWalletEndpoints(t *testing.T) {
 
 	var (
 		ctx       = context.Background()
-		accountID = "ebbf46c6-122a-4367-bc45-7dd555e1d3b9"
+		accountID = testtools.MERCHANT_ID
 	)
 
-	createdWallet, err := mc.CreateWallet(ctx, accountID, moov.CreateWallet{
-		Name:        "general wallet for v2604 test",
-		Description: "initial description",
-		Metadata:    map[string]string{"foo": "bar"},
-	})
+	wallets, err := mc.ListWallets(ctx, accountID, moov.WithWalletStatus(moov.WalletStatus_Active))
 	require.NoError(t, err)
-	require.NotEmpty(t, createdWallet.Description)
-	require.NotEmpty(t, createdWallet.Metadata)
-	t.Logf("Created wallet: %+v", createdWallet)
+
+	var walletID string
+	for _, w := range wallets {
+		if w.WalletType == moov.WalletType_General {
+			walletID = w.WalletID
+			t.Logf("Reusing existing general wallet: %s", walletID)
+			break
+		}
+	}
+	if walletID == "" {
+		created, err := mc.CreateWallet(ctx, accountID, moov.CreateWallet{
+			Name:        "general wallet for v2604 test",
+			Description: "initial description",
+			Metadata:    map[string]string{"foo": "bar"},
+		})
+		require.NoError(t, err)
+		walletID = created.WalletID
+		t.Logf("Created wallet: %+v", created)
+	}
 
 	t.Run("v2604.UpdateWallet unsets the description and metadata", func(t *testing.T) {
-		updatedWallet, err := walletClientV2604.UpdateWallet(ctx, accountID, createdWallet.WalletID, mv2604.UpdateWallet{
+		updatedWallet, err := walletClientV2604.UpdateWallet(ctx, accountID, walletID, mv2604.UpdateWallet{
 			Description: moov.SetNull[string](),
 			Metadata:    moov.SetNull[map[string]string](),
 		})
@@ -93,7 +106,7 @@ func TestWalletEndpoints(t *testing.T) {
 		require.Empty(t, updatedWallet.Metadata)
 		t.Logf("unset description and metadata in wallet: %+v", updatedWallet)
 
-		fetchedWallet, err := mc.GetWallet(ctx, accountID, createdWallet.WalletID)
+		fetchedWallet, err := mc.GetWallet(ctx, accountID, walletID)
 		require.NoError(t, err)
 		require.Empty(t, fetchedWallet.Description)
 		require.Empty(t, fetchedWallet.Metadata)

--- a/examples/wallets/wallet_test.go
+++ b/examples/wallets/wallet_test.go
@@ -3,8 +3,12 @@ package wallets
 import (
 	"context"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2604"
 )
 
 func ExampleClient_wallet() {
@@ -57,4 +61,42 @@ func ExampleClient_wallet() {
 		return
 	}
 	fmt.Printf("listed active wallets: %+v\n", listedWallets)
+}
+
+func TestWalletEndpoints(t *testing.T) {
+	mc, err := moov.NewClient()
+	require.NoError(t, err)
+	walletClientV2604 := mv2604.NewWalletClient(mc)
+
+	var (
+		ctx       = context.Background()
+		accountID = "ebbf46c6-122a-4367-bc45-7dd555e1d3b9"
+	)
+
+	createdWallet, err := mc.CreateWallet(ctx, accountID, moov.CreateWallet{
+		Name:        "general wallet for v2604 test",
+		Description: "initial description",
+		Metadata:    map[string]string{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createdWallet.Description)
+	require.NotEmpty(t, createdWallet.Metadata)
+	t.Logf("Created wallet: %+v", createdWallet)
+
+	t.Run("v2604.UpdateWallet unsets the description and metadata", func(t *testing.T) {
+		updatedWallet, err := walletClientV2604.UpdateWallet(ctx, accountID, createdWallet.WalletID, mv2604.UpdateWallet{
+			Description: moov.SetNull[string](),
+			Metadata:    moov.SetNull[map[string]string](),
+		})
+		require.NoError(t, err)
+		require.Empty(t, updatedWallet.Description)
+		require.Empty(t, updatedWallet.Metadata)
+		t.Logf("unset description and metadata in wallet: %+v", updatedWallet)
+
+		fetchedWallet, err := mc.GetWallet(ctx, accountID, createdWallet.WalletID)
+		require.NoError(t, err)
+		require.Empty(t, fetchedWallet.Description)
+		require.Empty(t, fetchedWallet.Metadata)
+		t.Logf("got wallet with unset description and metadata: %+v", fetchedWallet)
+	})
 }

--- a/examples/wallets/wallet_test.go
+++ b/examples/wallets/wallet_test.go
@@ -74,7 +74,7 @@ func TestWalletEndpoints(t *testing.T) {
 		accountID = testtools.MERCHANT_ID
 	)
 
-	wallets, err := mc.ListWallets(ctx, accountID, moov.WithWalletStatus(moov.WalletStatus_Active))
+	wallets, err := walletClientV2604.ListWallets(ctx, accountID, moov.WithWalletStatus(moov.WalletStatus_Active))
 	require.NoError(t, err)
 
 	var walletID string
@@ -86,7 +86,7 @@ func TestWalletEndpoints(t *testing.T) {
 		}
 	}
 	if walletID == "" {
-		created, err := mc.CreateWallet(ctx, accountID, moov.CreateWallet{
+		created, err := walletClientV2604.CreateWallet(ctx, accountID, moov.CreateWallet{
 			Name:        "general wallet for v2604 test",
 			Description: "initial description",
 			Metadata:    map[string]string{"foo": "bar"},
@@ -106,7 +106,7 @@ func TestWalletEndpoints(t *testing.T) {
 		require.Empty(t, updatedWallet.Metadata)
 		t.Logf("unset description and metadata in wallet: %+v", updatedWallet)
 
-		fetchedWallet, err := mc.GetWallet(ctx, accountID, walletID)
+		fetchedWallet, err := walletClientV2604.GetWallet(ctx, accountID, walletID)
 		require.NoError(t, err)
 		require.Empty(t, fetchedWallet.Description)
 		require.Empty(t, fetchedWallet.Metadata)

--- a/internal/testtools/wallet.go
+++ b/internal/testtools/wallet.go
@@ -1,0 +1,16 @@
+package testtools
+
+import (
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+// FindMerchantWalletPaymentMethod returns the moov-wallet payment method whose
+// wallet ID matches MERCHANT_WALLET_ID. Returns the zero value and false if not found.
+func FindMerchantWalletPaymentMethod(pms []moov.PaymentMethod) (moov.PaymentMethod, bool) {
+	for _, pm := range pms {
+		if pm.Wallet != nil && pm.Wallet.WalletID == MERCHANT_WALLET_ID {
+			return pm, true
+		}
+	}
+	return moov.PaymentMethod{}, false
+}

--- a/pkg/moov/wallet.go
+++ b/pkg/moov/wallet.go
@@ -2,6 +2,7 @@ package moov
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -194,6 +195,27 @@ func (c Client) UpdateWallet(ctx context.Context, accountID string, walletID str
 	resp, err := c.CallHttp(ctx, Endpoint(http.MethodPatch, pathWallet, accountID, walletID), AcceptJson(), JsonBody(update))
 	if err != nil {
 		return nil, err
+	}
+
+	return CompletedObjectOrError[Wallet](resp)
+}
+
+/* Exported functions used only for making client calls in the versioned packages (e.g. mv2604) */
+
+func UpdateWalletGeneric[T any](ctx context.Context, client *Client, version Version, accountID string, walletID string, update T) (*Wallet, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
+
+	resp, err := client.CallHttp(
+		ctx,
+		Endpoint(http.MethodPatch, pathWallet, accountID, walletID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(update),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("updating wallet: %w", err)
 	}
 
 	return CompletedObjectOrError[Wallet](resp)

--- a/pkg/mv2604/wallet_api.go
+++ b/pkg/mv2604/wallet_api.go
@@ -7,19 +7,20 @@ import (
 )
 
 type WalletClient struct {
-	client *moov.Client
+	*moov.Client
 }
 
 func NewWalletClient(client *moov.Client) WalletClient {
-	return WalletClient{client: client}
+	return WalletClient{Client: client}
 }
 
 func (w WalletClient) UpdateWallet(ctx context.Context, accountID, walletID string, update UpdateWallet) (*moov.Wallet, error) {
-	return moov.UpdateWalletGeneric(ctx, w.client, moov.Version2026_04, accountID, walletID, update)
+	return moov.UpdateWalletGeneric(ctx, w.Client, moov.Version2026_04, accountID, walletID, update)
 }
 
 type UpdateWallet struct {
-	moov.UpdateWallet
+	Name   *string            `json:"name,omitempty"`
+	Status *moov.WalletStatus `json:"status,omitempty"`
 
 	// A free-form description of the wallet.
 	Description *moov.Nullable[string] `json:"description,omitempty"`

--- a/pkg/mv2604/wallet_api.go
+++ b/pkg/mv2604/wallet_api.go
@@ -1,0 +1,28 @@
+package mv2604
+
+import (
+	"context"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type WalletClient struct {
+	client *moov.Client
+}
+
+func NewWalletClient(client *moov.Client) WalletClient {
+	return WalletClient{client: client}
+}
+
+func (w WalletClient) UpdateWallet(ctx context.Context, accountID, walletID string, update UpdateWallet) (*moov.Wallet, error) {
+	return moov.UpdateWalletGeneric(ctx, w.client, moov.Version2026_04, accountID, walletID, update)
+}
+
+type UpdateWallet struct {
+	moov.UpdateWallet
+
+	// A free-form description of the wallet.
+	Description *moov.Nullable[string] `json:"description,omitempty"`
+	// Free-form key-value pair list. Useful for storing information that is not captured elsewhere.
+	Metadata *moov.Nullable[map[string]string] `json:"metadata,omitempty"`
+}


### PR DESCRIPTION
## Context

Following the same pattern as #329 (sweep configs), updating the wallet PATCH endpoint model to support `Nullable[T]` on optional fields, without breaking existing integrations to the unversioned PATCH endpoint.

## Changes

- `pkg/moov/wallet.go` — adds `UpdateWalletGeneric[T]` exported generic function for the `mvyymm` versioned packages to call with specific versioning.
- `pkg/mv2604/wallet_api.go` — adds `mv2604.WalletClient.UpdateWallet` which extends `moov.UpdateWallet` with `Nullable[T]`-typed `Description` and `Metadata` fields, allowing callers to explicitly null out these wallet values.
- `examples/wallets/wallet_test.go` — adds test demonstrating unset via `moov.SetNull[string]()` and `moov.SetNull[map[string]string]()`.
- Update failing tests that expect to see only 1 `moov-wallet` payment method for the test partner account to expect at least 1, and to use the default `moov-wallet` if needed in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)