### PR TITLE
Add Google Pay payment method type and models

### DIFF
--- a/pkg/moov/google_pay_test.go
+++ b/pkg/moov/google_pay_test.go
@@ -1,0 +1,52 @@
+package moov_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGooglePayPaymentMethodMarshal(t *testing.T) {
+	input := []byte(`{
+		"paymentMethodID": "c3f8c4d0-7b1a-4e2a-9c5b-1234567890ab",
+		"paymentMethodType": "google-pay",
+		"googlePay": {
+			"tokenID": "b0a1c2d3-e4f5-6789-abcd-ef0123456789",
+			"brand": "Visa",
+			"cardType": "debit",
+			"cardDisplayName": "Visa 1234",
+			"fingerprint": "9948962d92a1ce40c9f918cd9ece3a22bde62fb325a2f1fe2e833969de672ba3",
+			"expiration": {
+				"month": "01",
+				"year": "29"
+			},
+			"dynamicLastFour": "1234",
+			"issuerCountry": "US",
+			"authMethod": "CRYPTOGRAM_3DS"
+		}
+	}`)
+
+	pm := new(moov.PaymentMethod)
+
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(pm)
+
+	require.NoError(t, err)
+	require.NotNil(t, pm.GooglePay)
+	assert.Equal(t, "b0a1c2d3-e4f5-6789-abcd-ef0123456789", pm.GooglePay.TokenID)
+	assert.Equal(t, moov.CardBrand("Visa"), pm.GooglePay.Brand)
+	assert.Equal(t, moov.CardType("debit"), pm.GooglePay.CardType)
+	assert.Equal(t, "Visa 1234", pm.GooglePay.CardDisplayName)
+	assert.Equal(t, "9948962d92a1ce40c9f918cd9ece3a22bde62fb325a2f1fe2e833969de672ba3", pm.GooglePay.Fingerprint)
+	assert.Equal(t, "01", pm.GooglePay.Expiration.Month)
+	assert.Equal(t, "29", pm.GooglePay.Expiration.Year)
+	assert.Equal(t, "1234", pm.GooglePay.DynamicLastFour)
+	assert.Equal(t, "US", pm.GooglePay.IssuerCountry)
+	assert.Equal(t, "CRYPTOGRAM_3DS", pm.GooglePay.AuthMethod)
+}

--- a/pkg/moov/google_pay_test.go
+++ b/pkg/moov/google_pay_test.go
@@ -48,5 +48,5 @@ func TestGooglePayPaymentMethodMarshal(t *testing.T) {
 	assert.Equal(t, "29", pm.GooglePay.Expiration.Year)
 	assert.Equal(t, "1234", pm.GooglePay.DynamicLastFour)
 	assert.Equal(t, "US", pm.GooglePay.IssuerCountry)
-	assert.Equal(t, "CRYPTOGRAM_3DS", pm.GooglePay.AuthMethod)
+	assert.Equal(t, moov.GooglePayAuthMethod_Cryptogram3DS, pm.GooglePay.AuthMethod)
 }

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -8,6 +8,7 @@ type PaymentMethod struct {
 	BankAccount       *BankAccountPaymentMethod `json:"bankAccount,omitempty"`
 	Card              *CardPaymentMethod        `json:"card,omitempty"`
 	ApplePay          *ApplePayPaymentMethod    `json:"applePay,omitempty"`
+	GooglePay         *GooglePayPaymentMethod   `json:"googlePay,omitempty"`
 }
 
 // BasicPaymentMethod struct for BasicPaymentMethod
@@ -33,6 +34,9 @@ const (
 	PaymentMethodType_PullFromCard       PaymentMethodType = "pull-from-card"
 	PaymentMethodType_PushToApplePay     PaymentMethodType = "push-to-apple-pay"
 	PaymentMethodType_PullFromApplePay   PaymentMethodType = "pull-from-apple-pay"
+	PaymentMethodType_GooglePay          PaymentMethodType = "google-pay"
+	PaymentMethodType_PushToGooglePay    PaymentMethodType = "push-to-google-pay"
+	PaymentMethodType_PullFromGooglePay  PaymentMethodType = "pull-from-google-pay"
 	PaymentMethodType_CardPresentPayment PaymentMethodType = "card-present-payment"
 	PaymentMethodType_InstantBankCredit  PaymentMethodType = "instant-bank-credit" // #nosec G101
 )
@@ -70,6 +74,19 @@ type CardPaymentMethod struct {
 	DomesticPullFromCard DomesticPullFromCard `json:"domesticPullFromCard,omitempty"`
 	// Includes any payment methods generated for a newly linked card, removing the need to  call the List Payment Methods endpoint following a successful Link Card request.  **NOTE: This field is only populated for Link Card requests made with the `X-Wait-For` header.**
 	PaymentMethods []BasicPaymentMethod `json:"paymentMethods,omitempty"`
+}
+
+// GooglePayPaymentMethod Describes a Google Pay token on a Moov account.
+type GooglePayPaymentMethod struct {
+	TokenID         string         `json:"tokenID,omitempty"`
+	Brand           CardBrand      `json:"brand,omitempty"`
+	CardType        CardType       `json:"cardType,omitempty"`
+	CardDisplayName string         `json:"cardDisplayName,omitempty"`
+	Fingerprint     string         `json:"fingerprint,omitempty"`
+	Expiration      CardExpiration `json:"expiration,omitempty"`
+	DynamicLastFour string         `json:"dynamicLastFour,omitempty"`
+	IssuerCountry   string         `json:"issuerCountry,omitempty"`
+	AuthMethod      string         `json:"authMethod,omitempty"` // "PAN_ONLY" | "CRYPTOGRAM_3DS"
 }
 
 // ApplePayResponse Describes an Apple Pay token on a Moov account.

--- a/pkg/moov/payment_method_models.go
+++ b/pkg/moov/payment_method_models.go
@@ -76,17 +76,26 @@ type CardPaymentMethod struct {
 	PaymentMethods []BasicPaymentMethod `json:"paymentMethods,omitempty"`
 }
 
+// GooglePayAuthMethod The authentication method used for a Google Pay token.
+type GooglePayAuthMethod string
+
+// List of GooglePayAuthMethod
+const (
+	GooglePayAuthMethod_PanOnly       GooglePayAuthMethod = "PAN_ONLY"
+	GooglePayAuthMethod_Cryptogram3DS GooglePayAuthMethod = "CRYPTOGRAM_3DS"
+)
+
 // GooglePayPaymentMethod Describes a Google Pay token on a Moov account.
 type GooglePayPaymentMethod struct {
-	TokenID         string         `json:"tokenID,omitempty"`
-	Brand           CardBrand      `json:"brand,omitempty"`
-	CardType        CardType       `json:"cardType,omitempty"`
-	CardDisplayName string         `json:"cardDisplayName,omitempty"`
-	Fingerprint     string         `json:"fingerprint,omitempty"`
-	Expiration      CardExpiration `json:"expiration,omitempty"`
-	DynamicLastFour string         `json:"dynamicLastFour,omitempty"`
-	IssuerCountry   string         `json:"issuerCountry,omitempty"`
-	AuthMethod      string         `json:"authMethod,omitempty"` // "PAN_ONLY" | "CRYPTOGRAM_3DS"
+	TokenID         string              `json:"tokenID,omitempty"`
+	Brand           CardBrand           `json:"brand,omitempty"`
+	CardType        CardType            `json:"cardType,omitempty"`
+	CardDisplayName string              `json:"cardDisplayName,omitempty"`
+	Fingerprint     string              `json:"fingerprint,omitempty"`
+	Expiration      CardExpiration      `json:"expiration,omitempty"`
+	DynamicLastFour string              `json:"dynamicLastFour,omitempty"`
+	IssuerCountry   string              `json:"issuerCountry,omitempty"`
+	AuthMethod      GooglePayAuthMethod `json:"authMethod,omitempty"`
 }
 
 // ApplePayResponse Describes an Apple Pay token on a Moov account.


### PR DESCRIPTION
Adds read-side Google Pay support to the payment-method API surface. Google Pay was added to moov-api in v2026.04 but was missing from the SDK — callers had no typed way to read `googlePay` details off a `PaymentMethod` response or refer to the payment method types by constant.

## Changes

- Add `GooglePayPaymentMethod` struct mirroring the v2026.04 `GooglePayResponse` shape (includes `tokenID`, `authMethod`, `issuerCountry` — not omitted like the existing Apple Pay struct)
- Add `GooglePay *GooglePayPaymentMethod` field to the `PaymentMethod` envelope
- Add `PaymentMethodType_GooglePay`, `PaymentMethodType_PushToGooglePay`, `PaymentMethodType_PullFromGooglePay` constants alongside the Apple Pay equivalents
- Add `TestGooglePayPaymentMethodMarshal` round-trip JSON test with `DisallowUnknownFields`

A follow-up branch adds `GooglePay` to `TransferSource` and `TransferDestination`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)