### PR TITLE
Add GooglePay field to TransferSource and TransferDestination

### DIFF
--- a/pkg/moov/google_pay_test.go
+++ b/pkg/moov/google_pay_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,58 @@ func TestGooglePayPaymentMethodMarshal(t *testing.T) {
 	assert.Equal(t, "1234", pm.GooglePay.DynamicLastFour)
 	assert.Equal(t, "US", pm.GooglePay.IssuerCountry)
 	assert.Equal(t, moov.GooglePayAuthMethod_Cryptogram3DS, pm.GooglePay.AuthMethod)
+}
+
+func TestGooglePayTransferMarshal(t *testing.T) {
+	googlePayJSON := `{
+		"tokenID": "b0a1c2d3-e4f5-6789-abcd-ef0123456789",
+		"brand": "Visa",
+		"cardType": "debit",
+		"cardDisplayName": "Visa 1234",
+		"fingerprint": "9948962d92a1ce40c9f918cd9ece3a22bde62fb325a2f1fe2e833969de672ba3",
+		"expiration": {"month": "01", "year": "29"},
+		"dynamicLastFour": "1234",
+		"issuerCountry": "US",
+		"authMethod": "CRYPTOGRAM_3DS"
+	}`
+
+	transferInput := []byte(`{
+		"transferID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		"createdOn": "2026-04-01T00:00:00Z",
+		"status": "completed",
+		"amount": {"currency": "USD", "value": 1000},
+		"source": {
+			"paymentMethodID": "c3f8c4d0-7b1a-4e2a-9c5b-1234567890ab",
+			"paymentMethodType": "google-pay",
+			"account": {"accountID": "acc-111", "email": "payer@example.com", "displayName": "Payer"},
+			"googlePay": ` + googlePayJSON + `
+		},
+		"destination": {
+			"paymentMethodID": "d4e5f6a7-b8c9-0123-def0-123456789abc",
+			"paymentMethodType": "moov-wallet",
+			"account": {"accountID": "acc-222", "email": "payee@example.com", "displayName": "Payee"},
+			"wallet": {"walletID": "wallet-123"}
+		}
+	}`)
+
+	xfr := new(moov.Transfer)
+
+	dec := json.NewDecoder(bytes.NewReader(transferInput))
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(xfr)
+
+	require.NoError(t, err)
+	assert.Equal(t, "a1b2c3d4-e5f6-7890-abcd-ef1234567890", xfr.TransferID)
+	assert.Equal(t, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), xfr.CreatedOn)
+
+	require.NotNil(t, xfr.Source.GooglePay)
+	assert.Equal(t, "b0a1c2d3-e4f5-6789-abcd-ef0123456789", xfr.Source.GooglePay.TokenID)
+	assert.Equal(t, moov.CardBrand("Visa"), xfr.Source.GooglePay.Brand)
+	assert.Equal(t, "9948962d92a1ce40c9f918cd9ece3a22bde62fb325a2f1fe2e833969de672ba3", xfr.Source.GooglePay.Fingerprint)
+	assert.Equal(t, "US", xfr.Source.GooglePay.IssuerCountry)
+
+	assert.Nil(t, xfr.Destination.GooglePay)
+	require.NotNil(t, xfr.Destination.Wallet)
+	assert.Equal(t, "wallet-123", xfr.Destination.Wallet.WalletID)
 }

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -286,6 +286,7 @@ type TransferSource struct {
 	Wallet            *WalletPaymentMethod       `json:"wallet,omitempty"`
 	Card              *CardPaymentMethod         `json:"card,omitempty"`
 	ApplePay          *ApplePayPaymentMethod     `json:"applePay,omitempty"`
+	GooglePay         *GooglePayPaymentMethod    `json:"googlePay,omitempty"`
 	AchDetails        *AchDetailsSource          `json:"achDetails,omitempty"`
 	CardDetails       *CardDetails               `json:"cardDetails,omitempty"`
 	TerminalCard      *TerminalCardPaymentMethod `json:"terminalCard,omitempty"`
@@ -345,6 +346,7 @@ type TransferDestination struct {
 	Wallet            *WalletPaymentMethod      `json:"wallet,omitempty"`
 	Card              *CardPaymentMethod        `json:"card,omitempty"`
 	ApplePay          *ApplePayPaymentMethod    `json:"applePay,omitempty"`
+	GooglePay         *GooglePayPaymentMethod   `json:"googlePay,omitempty"`
 	AchDetails        *AchDetails               `json:"achDetails,omitempty"`
 	CardDetails       *CardDetails              `json:"cardDetails,omitempty"`
 	// RtpDetails is deprecated; use InstantBankDetails instead


### PR DESCRIPTION
Extends read-side Google Pay support to the transfers API. Builds on #336 which introduced `GooglePayPaymentMethod` — this PR exposes it on transfer responses where a Google Pay payment method was used as source or destination.

## Changes

- Add `GooglePay *GooglePayPaymentMethod` to `TransferSource`
- Add `GooglePay *GooglePayPaymentMethod` to `TransferDestination`
- Add `TestGooglePayTransferMarshal`: decodes a v2026.04-shaped transfer with `source.googlePay` nested correctly, using `DisallowUnknownFields`

Fields are `omitempty` — `nil` on pre-v2026.04 responses, populated on v2026.04+. Because `mv2607.Transfer` embeds `moov.Transfer`, the new fields propagate to the v2026.07+ overlay automatically with no additional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)