### PR TITLE
feat: add ListCancellations to transfers SDK

### DIFF
--- a/pkg/moov/transfer_api.go
+++ b/pkg/moov/transfer_api.go
@@ -548,6 +548,18 @@ func (c Client) GetCancellation(ctx context.Context, accountID string, transferI
 	return CompletedObjectOrError[Cancellation](resp)
 }
 
+func (c Client) ListCancellations(ctx context.Context, accountID string, transferID string) ([]Cancellation, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathCancellations, accountID, transferID),
+		AcceptJson(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedListOrError[Cancellation](resp)
+}
+
 // TransferOptions lists all transfer options between a source and destination
 // https://docs.moov.io/api/#tag/Transfers/operation/createTransferOptions
 func (c Client) TransferOptions(ctx context.Context, partnerAccountID string, payload CreateTransferOptions) (*TransferOptions, error) {

--- a/pkg/moov/transfer_test.go
+++ b/pkg/moov/transfer_test.go
@@ -241,5 +241,12 @@ func Test_Cancellations(t *testing.T) {
 		fetchedCancellation, err := mc.GetCancellation(BgCtx(), FACILITATOR_ID, transferID, createdCancellation.CancellationID)
 		NoResponseError(t, err)
 		require.Equal(t, createdCancellation.CancellationID, fetchedCancellation.CancellationID)
+
+		t.Run("list cancellations", func(t *testing.T) {
+			cancellations, err := mc.ListCancellations(BgCtx(), FACILITATOR_ID, transferID)
+			NoResponseError(t, err)
+			require.Len(t, cancellations, 1)
+			require.Equal(t, createdCancellation.CancellationID, cancellations[0].CancellationID)
+		})
 	})
 }


### PR DESCRIPTION
## Why
Exposes the new LIST cancellations endpoint in the Go SDK. LEDG-4147.

Adds `Client.ListCancellations(ctx, accountID, transferID)`, mirroring `ListRefunds`.