### PR TITLE
(issuing)!: Change endpoints from /issued-cards to /cards

### DIFF
--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -132,8 +132,8 @@ const (
 	pathInvoice         = "/accounts/%s/invoices/%s"
 	pathInvoicePayments = "/accounts/%s/invoices/%s/payments"
 
-	pathIssuedCards                = "/issuing/%s/issued-cards"
-	pathIssuedCard                 = "/issuing/%s/issued-cards/%s"
+	pathIssuedCards                = "/issuing/%s/cards"
+	pathIssuedCard                 = "/issuing/%s/cards/%s"
 	pathIssuingAuthorizations      = "/issuing/%s/authorizations"
 	pathIssuingAuthorization       = "/issuing/%s/authorizations/%s"
 	pathIssuingAuthorizationEvents = "/issuing/%s/authorizations/%s/events"


### PR DESCRIPTION
change card-issuing endpoints from /issued-cards to /cards

this is a breaking change, but card issuing is still in a closed beta and currently has no active users to be impacted