### PR TITLE
issuing: align card models with latest contract; remove deprecated states

### DIFF
--- a/examples/card_issuing/issuing_test.go
+++ b/examples/card_issuing/issuing_test.go
@@ -42,22 +42,16 @@ func TestCardIssuing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Step 4: get the source wallet for funding the issued card
+	// Step 4: create an issued card
 
-	// For now just using a known existing wallet for the account
-	walletID := "4dbac313-d505-4d51-a0fe-c11787916fcf"
-
-	// Step 5: create an issued card
-
-	memo := "example"
+	// The card is issued to the business account identified by accountID above, and is funded
+	// from that business account's default wallet (resolved server-side).
+	//
+	// AuthorizedUserAccountID is optional: it names a second cardholder on the card. Omit it to
+	// issue the card without one.
+	nickname := "example"
 	create := moov.CreateIssuedCard{
-		FundingWalletID: walletID,
-		AuthorizedUser: moov.CreateAuthorizedUser{
-			FirstName: "John",
-			LastName:  "Doe",
-		},
-		FormFactor: moov.IssuedCardFormFactor_Virtual,
-		Memo:       &memo,
+		Nickname: &nickname,
 	}
 	created, err := mc.CreateIssuedCard(ctx, accountID, create)
 	require.NoError(t, err)

--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -43,12 +43,6 @@ const (
 	// operational and can approve incoming authorizations
 	IssuedCardState_Active IssuedCardState = "active"
 
-	// still in the activation process and cannot yet approve incoming authorizations
-	IssuedCardState_Inactive IssuedCardState = "inactive"
-
-	// awaiting additional AuthorizedUser verification before the card can become active
-	IssuedCardState_PendingVerification IssuedCardState = "pending-verification"
-
 	// permanently deactivated, either by request or because it expired, and cannot approve incoming authorizations
 	IssuedCardState_Closed IssuedCardState = "closed"
 )

--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -6,20 +6,20 @@ import (
 )
 
 type IssuedCard struct {
-	IssuedCardID       string               `json:"issuedCardID"`
-	Brand              IssuedCardBrand      `json:"brand"`
-	LastFourCardNumber string               `json:"lastFourCardNumber"`
-	Expiration         IssuedCardExpiration `json:"expiration"`
-	AuthorizedUser     AuthorizedUser       `json:"authorizedUser"`
-	Memo               *string              `json:"memo,omitempty"`
-	Nickname           *string              `json:"nickname,omitempty"`
-	FundingWalletID    string               `json:"fundingWalletID"`
-	State              IssuedCardState      `json:"state"`
-	FormFactor         IssuedCardFormFactor `json:"formFactor"`
-	Controls           *IssuingControls     `json:"controls,omitempty"`
-	Metadata           map[string]string    `json:"metadata,omitempty"`
-	CreatedOn          time.Time            `json:"createdOn"`
-	UpdatedOn          time.Time            `json:"updatedOn"`
+	IssuedCardID            string               `json:"issuedCardID"`
+	Brand                   IssuedCardBrand      `json:"brand"`
+	LastFourCardNumber      string               `json:"lastFourCardNumber"`
+	Expiration              IssuedCardExpiration `json:"expiration"`
+	AuthorizedUserAccountID *string              `json:"authorizedUserAccountID,omitempty"`
+	Nickname                *string              `json:"nickname,omitempty"`
+	FundingWalletID         string               `json:"fundingWalletID"`
+	State                   IssuedCardState      `json:"state"`
+	FormFactor              IssuedCardFormFactor `json:"formFactor"`
+	BillingAddress          *Address             `json:"billingAddress,omitempty"`
+	Controls                *IssuingControls     `json:"controls,omitempty"`
+	Metadata                map[string]string    `json:"metadata,omitempty"`
+	CreatedOn               time.Time            `json:"createdOn"`
+	UpdatedOn               time.Time            `json:"updatedOn"`
 }
 
 type IssuedCardBrand string
@@ -34,11 +34,6 @@ const (
 type IssuedCardExpiration struct {
 	Month string `json:"month,omitempty"`
 	Year  string `json:"year,omitempty"`
-}
-
-type AuthorizedUser struct {
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
 }
 
 // IssuedCardState represents the operational status of an IssuedCard
@@ -111,30 +106,19 @@ func WithIssuedCardCount(count int) ListIssuedCardsFilter {
 }
 
 type CreateIssuedCard struct {
-	FundingWalletID string                `json:"fundingWalletID"`
-	AuthorizedUser  CreateAuthorizedUser  `json:"authorizedUser"`
-	FormFactor      IssuedCardFormFactor  `json:"formFactor"`
-	Memo            *string               `json:"memo,omitempty"`
-	Expiration      *IssuedCardExpiration `json:"expiration,omitempty"`
-	Controls        *IssuingControls      `json:"controls,omitempty"`
-}
-
-type CreateAuthorizedUser struct {
-	FirstName string     `json:"firstName"`
-	LastName  string     `json:"lastName"`
-	BirthDate *BirthDate `json:"birthDate,omitempty"`
-}
-
-type BirthDate struct {
-	Day   int32 `json:"day"`
-	Month int32 `json:"month"`
-	Year  int32 `json:"year"`
+	AuthorizedUserAccountID *string               `json:"authorizedUserAccountID,omitempty"`
+	Nickname                *string               `json:"nickname,omitempty"`
+	Metadata                map[string]string     `json:"metadata,omitempty"`
+	BillingAddress          *Address              `json:"billingAddress,omitempty"`
+	Expiration              *IssuedCardExpiration `json:"expiration,omitempty"`
+	Controls                *IssuingControls      `json:"controls,omitempty"`
 }
 
 type UpdateIssuedCard struct {
 	State          *UpdateIssuedCardState `json:"state,omitempty"`
-	Memo           *string                `json:"memo,omitempty"`
-	AuthorizedUser *CreateAuthorizedUser  `json:"authorizedUser,omitempty"`
+	Nickname       *string                `json:"nickname,omitempty"`
+	Metadata       map[string]string      `json:"metadata,omitempty"`
+	BillingAddress *AddressPatch          `json:"billingAddress,omitempty"`
 }
 
 type UpdateIssuedCardState string

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -156,7 +156,6 @@ func Test_CardIssuing(t *testing.T) {
 	cards, err := mc.ListIssuedCards(BgCtx(), MERCHANT_ID,
 		moov.WithIssuedCardStates([]moov.IssuedCardState{
 			moov.IssuedCardState_Active,
-			moov.IssuedCardState_PendingVerification,
 		}))
 	NoResponseError(t, err)
 	require.NotEmpty(t, cards)

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -20,13 +20,21 @@ func TestIssuedCardMarshal(t *testing.T) {
 				"month": "01",
 				"year": "21"
 			},
-			"authorizedUser": {
-				"firstName": "Jules",
-				"lastName": "Jackson"
-			},
+			"authorizedUserAccountID": "a06f9j41-5e3e-4f4a-9b1e-2c3d4e5f6a7b",
+			"nickname": "Travel card",
 			"fundingWalletID": "50469144-f859-46dc-bdbd-9587c2fa7b42",
 			"state": "active",
 			"formFactor": "virtual",
+			"billingAddress": {
+				"addressLine1": "123 Main St",
+				"city": "Longmont",
+				"stateOrProvince": "CO",
+				"postalCode": "80525",
+				"country": "US"
+			},
+			"metadata": {
+				"program": "rewards"
+			},
 			"createdOn": "2023-11-08T22:06:16Z"
 		}`)
 
@@ -129,17 +137,14 @@ func TestIssuedCardTransactionMarshal(t *testing.T) {
 
 func Test_CardIssuing(t *testing.T) {
 	mc := NewTestClient(t)
-	memo := "testing"
+	nickname := "testing"
 
 	// create issued card
+	// The card is issued to (and funded by the default wallet of) the MERCHANT_ID business
+	// account. AuthorizedUserAccountID (an optional second cardholder) is omitted.
 	created, err := mc.CreateIssuedCard(BgCtx(), MERCHANT_ID, moov.CreateIssuedCard{
-		FundingWalletID: MERCHANT_WALLET_ID,
-		AuthorizedUser: moov.CreateAuthorizedUser{
-			FirstName: "John",
-			LastName:  "Doe",
-		},
-		FormFactor: moov.IssuedCardFormFactor_Virtual,
-		Memo:       &memo,
+		Nickname: &nickname,
+		Metadata: map[string]string{"program": "testing"},
 	})
 	NoResponseError(t, err)
 	require.NotNil(t, created)


### PR DESCRIPTION
Updates the hand-written card-issuing models to match the latest `moov-api-models` contract (ISSU-1229). The `IssuedCard`/`CreateIssuedCard`/`UpdateIssuedCard` types now use `authorizedUserAccountID`, `nickname`, `metadata`, and `billingAddress`, dropping the embedded `AuthorizedUser`/`BirthDate`, `memo`, `formFactor`, and create-time `fundingWalletID` (the card is issued to and funded from the business account's default wallet). The `IssuedCardState` enum is reduced to `active` and `closed`, removing the now-deprecated `inactive` and `pending-verification` (watchlist-check) states. Unit/marshal tests and the example were updated to the new contract, and `go build`/`go vet`/marshal tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)