### PR TITLE
feat(transfers): add GetTransferRiskOutcomes SDK method (COR-4326)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-faker/faker/v4 v4.7.0 h1:VboC02cXHl/NuQh5lM2W8b87yp4iFXIu59x4w0RZi4E=
-github.com/go-faker/faker/v4 v4.7.0/go.mod h1:u1dIRP5neLB6kTzgyVjdBOV5R1uP7BdxkcWk7tiKQXk=
-github.com/go-faker/faker/v4 v4.8.0 h1:QAKmb4TyAMxIgf3a8fXubQXwFFJviBGL2/IDa34N6JQ=
-github.com/go-faker/faker/v4 v4.8.0/go.mod h1:u1dIRP5neLB6kTzgyVjdBOV5R1uP7BdxkcWk7tiKQXk=
 github.com/go-faker/faker/v4 v4.9.0 h1:a4HXLwueuTCtgF93VpUsl8Zd2nG1VH2SgNWDPVEBg5U=
 github.com/go-faker/faker/v4 v4.9.0/go.mod h1:u1dIRP5neLB6kTzgyVjdBOV5R1uP7BdxkcWk7tiKQXk=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -76,6 +76,8 @@ const (
 	pathTransfers = "/accounts/%s/transfers"
 	pathTransfer  = "/accounts/%s/transfers/%s"
 
+	pathTransferRiskOutcomes = "/transfers/%s/risk-outcomes"
+
 	pathSchedules          = "/accounts/%s/schedules"
 	pathSchedule           = "/accounts/%s/schedules/%s"
 	pathScheduleOccurrence = "/accounts/%s/schedules/%s/occurrences/%s"

--- a/pkg/moov/riskoutcomes_api.go
+++ b/pkg/moov/riskoutcomes_api.go
@@ -1,0 +1,23 @@
+package moov
+
+import (
+	"context"
+	"net/http"
+)
+
+// GetTransferRiskOutcomes retrieves the risk rules that contributed to a
+// transfer's risk decision. Availability is limited to enrolled partners; the
+// account is resolved from the calling credentials.
+// https://docs.moov.io/api/money-movement/transfers/get-risk-outcomes/
+func (c Client) GetTransferRiskOutcomes(ctx context.Context, transferID string) (*TransferRiskOutcomes, error) {
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathTransferRiskOutcomes, transferID),
+		AcceptJson(),
+		MoovVersion(Version2026_10),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TransferRiskOutcomes](resp)
+}

--- a/pkg/moov/riskoutcomes_test.go
+++ b/pkg/moov/riskoutcomes_test.go
@@ -1,0 +1,27 @@
+package moov_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+func Test_GetTransferRiskOutcomes_NotFound(t *testing.T) {
+	mc := NewTestClient(t)
+
+	// The endpoint is partner-gated and collapses every denial path (not
+	// allowlisted, transfer not owned, no persisted outcome) to the same 404,
+	// so an unknown transfer ID is a deterministic not-found regardless of the
+	// calling account's allowlist status.
+	transferID := uuid.NewString()
+	outcomes, err := mc.GetTransferRiskOutcomes(context.Background(), transferID)
+	require.Nil(t, outcomes)
+
+	var httpErr moov.HttpCallResponse
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, moov.StatusNotFound, httpErr.Status())
+}

--- a/pkg/moov/transfer_models.go
+++ b/pkg/moov/transfer_models.go
@@ -711,3 +711,15 @@ const (
 	TransferParty_Destination TransferParty = "destination"
 	TransferParty_Partner     TransferParty = "partner"
 )
+
+// TransferRiskOutcomes lists the risk rules that contributed to a transfer's
+// risk decision. Availability is limited to enrolled partners.
+type TransferRiskOutcomes struct {
+	TransferID        string             `json:"transferID"`
+	ContributingRules []ContributingRule `json:"contributingRules"`
+}
+
+// ContributingRule is a risk rule that contributed to a transfer's risk decision.
+type ContributingRule struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## Summary

Adds a client method for the partner-facing `GET /transfers/{transferID}/risk-outcomes` endpoint (COR-4326), documenting/supporting the fraudwall partner endpoint shipped in COR-4288.

- `GetTransferRiskOutcomes(ctx, transferID)` returns `TransferRiskOutcomes` (`transferID` + `contributingRules[].name`).
- Sends `X-Moov-Version: v2026.10.00` (`Version2026_10`) to match the documented release version. The endpoint is served by the backend for all versions `>= v2026.04.00` via versioned-handler fall-through.
- The account is resolved from the calling credentials (partner allowlist + self-read), so no `accountID` parameter is required.
- `go.sum` tidied to drop orphaned `go-faker` checksums.

## Testing

- `go build ./pkg/moov/` and `go vet ./pkg/moov/` pass.
- Added `Test_GetTransferRiskOutcomes_NotFound` (live integration test; asserts the documented 404 for an unknown/non-allowlisted transfer). Full run requires `secrets.env`.

## Related

- Linear: COR-4326
- Docs: moov-api partner endpoint PR (documents this at v2026.10.00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)