### PR TITLE
fix: use versioned sweep config methods in mv2604 client

### DIFF
--- a/pkg/moov/sweep_api.go
+++ b/pkg/moov/sweep_api.go
@@ -137,6 +137,9 @@ func ListSweepConfigsGeneric(ctx context.Context, client *Client, version Versio
 	if client == nil {
 		return nil, fmt.Errorf("client is nil")
 	}
+	if accountID == "" {
+		return nil, fmt.Errorf("accountID is required")
+	}
 
 	resp, err := client.CallHttp(
 		ctx,
@@ -154,6 +157,12 @@ func ListSweepConfigsGeneric(ctx context.Context, client *Client, version Versio
 func GetSweepConfigGeneric(ctx context.Context, client *Client, version Version, accountID string, sweepConfigID string) (*SweepConfig, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is nil")
+	}
+	if accountID == "" {
+		return nil, fmt.Errorf("accountID is required")
+	}
+	if sweepConfigID == "" {
+		return nil, fmt.Errorf("sweepConfigID is required")
 	}
 
 	resp, err := client.CallHttp(
@@ -173,6 +182,9 @@ func CreateSweepConfigGeneric(ctx context.Context, client *Client, version Versi
 	if client == nil {
 		return nil, fmt.Errorf("client is nil")
 	}
+	if create.AccountID == "" {
+		return nil, fmt.Errorf("accountID is required")
+	}
 
 	resp, err := client.CallHttp(
 		ctx,
@@ -191,6 +203,12 @@ func CreateSweepConfigGeneric(ctx context.Context, client *Client, version Versi
 func UpdateSweepConfigGeneric[T any](ctx context.Context, client *Client, version Version, accountID string, sweepConfigID string, update T) (*SweepConfig, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is nil")
+	}
+	if accountID == "" {
+		return nil, fmt.Errorf("accountID is required")
+	}
+	if sweepConfigID == "" {
+		return nil, fmt.Errorf("sweepConfigID is required")
 	}
 
 	resp, err := client.CallHttp(

--- a/pkg/moov/sweep_api.go
+++ b/pkg/moov/sweep_api.go
@@ -133,6 +133,61 @@ func (c Client) GetSweep(ctx context.Context, accountID string, walletID string,
 
 /* Exported functions used only for making client calls in the versioned packages (e.g. mv2604) */
 
+func ListSweepConfigsGeneric(ctx context.Context, client *Client, version Version, accountID string) ([]SweepConfig, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
+
+	resp, err := client.CallHttp(
+		ctx,
+		Endpoint(http.MethodGet, pathSweepConfigs, accountID),
+		MoovVersion(version),
+		AcceptJson(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing sweep configs: %w", err)
+	}
+
+	return CompletedListOrError[SweepConfig](resp)
+}
+
+func GetSweepConfigGeneric(ctx context.Context, client *Client, version Version, accountID string, sweepConfigID string) (*SweepConfig, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
+
+	resp, err := client.CallHttp(
+		ctx,
+		Endpoint(http.MethodGet, pathSweepConfig, accountID, sweepConfigID),
+		MoovVersion(version),
+		AcceptJson(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting sweep config: %w", err)
+	}
+
+	return CompletedObjectOrError[SweepConfig](resp)
+}
+
+func CreateSweepConfigGeneric(ctx context.Context, client *Client, version Version, create CreateSweepConfig) (*SweepConfig, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
+
+	resp, err := client.CallHttp(
+		ctx,
+		Endpoint(http.MethodPost, pathSweepConfigs, create.AccountID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(create),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating sweep config: %w", err)
+	}
+
+	return CompletedObjectOrError[SweepConfig](resp)
+}
+
 func UpdateSweepConfigGeneric[T any](ctx context.Context, client *Client, version Version, accountID string, sweepConfigID string, update T) (*SweepConfig, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is nil")

--- a/pkg/mv2604/sweep_api.go
+++ b/pkg/mv2604/sweep_api.go
@@ -14,6 +14,18 @@ func NewSweepClient(client *moov.Client) SweepClient {
 	return SweepClient{Client: client}
 }
 
+func (s SweepClient) ListSweepConfigs(ctx context.Context, accountID string) ([]moov.SweepConfig, error) {
+	return moov.ListSweepConfigsGeneric(ctx, s.Client, moov.Version2026_04, accountID)
+}
+
+func (s SweepClient) GetSweepConfig(ctx context.Context, accountID string, sweepConfigID string) (*moov.SweepConfig, error) {
+	return moov.GetSweepConfigGeneric(ctx, s.Client, moov.Version2026_04, accountID, sweepConfigID)
+}
+
+func (s SweepClient) CreateSweepConfig(ctx context.Context, create moov.CreateSweepConfig) (*moov.SweepConfig, error) {
+	return moov.CreateSweepConfigGeneric(ctx, s.Client, moov.Version2026_04, create)
+}
+
 func (s SweepClient) UpdateSweepConfig(ctx context.Context, accountID, sweepConfigID string, update UpdateSweepConfig) (*moov.SweepConfig, error) {
 	return moov.UpdateSweepConfigGeneric(ctx, s.Client, moov.Version2026_04, accountID, sweepConfigID, update)
 }


### PR DESCRIPTION
## Problem

CI run [#29580178410](https://github.com/moovfinancial/moov-go/actions/runs/29580178410) failed on `TestSweepConfigsEndpoints/v2604.UpdateSweepConfig_unsets_the_statement_descriptor`.

The `mv2604.SweepClient` only had a versioned `UpdateSweepConfig` (sends `X-Moov-Version: v2026.04.00`). `ListSweepConfigs`, `GetSweepConfig`, and `CreateSweepConfig` resolved to the **embedded** `moov.Client` methods, which send **no version header** — so the backend used its default/latest version.

The latest version now returns a default `statementDescriptor` on GET (the 10-character ID per the spec) even after unsetting, while v2026.04 returns nil. This version mismatch caused `require.Nil` at `sweep_test.go:74` to fail.

## Fix

- Added `ListSweepConfigsGeneric`, `GetSweepConfigGeneric`, `CreateSweepConfigGeneric` to `pkg/moov/sweep_api.go`
- Added versioned `ListSweepConfigs`, `GetSweepConfig`, `CreateSweepConfig` methods to `mv2604.SweepClient` (`pkg/mv2604/sweep_api.go`)

These shadow the embedded `moov.Client` methods so the test uses v2026.04 consistently for all CRUD operations. No test changes needed.