### PR TITLE
feat(issuing): expose spend controls on card create/PATCH/GET

### DIFF
--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -96,7 +96,8 @@ type IssuedControls struct {
 }
 
 // UpdateIssuingControls specifies the mutable controls on a PATCH. Each field replaces the entire
-// corresponding value.
+// corresponding value. SingleUse is intentionally absent: it is set at card creation and is not
+// patchable, matching the moov-api PATCH surface.
 type UpdateIssuingControls struct {
 	// replaces the entire set of velocity limits; nil leaves them unchanged, a non-nil empty slice clears them
 	VelocityLimits *[]IssuingVelocityLimit `json:"velocityLimits,omitempty"`

--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -16,7 +16,7 @@ type IssuedCard struct {
 	State                   IssuedCardState      `json:"state"`
 	FormFactor              IssuedCardFormFactor `json:"formFactor"`
 	BillingAddress          *Address             `json:"billingAddress,omitempty"`
-	Controls                *IssuingControls     `json:"controls,omitempty"`
+	Controls                *IssuedControls      `json:"controls,omitempty"`
 	Metadata                map[string]string    `json:"metadata,omitempty"`
 	CreatedOn               time.Time            `json:"createdOn"`
 	UpdatedOn               time.Time            `json:"updatedOn"`
@@ -55,12 +55,63 @@ const (
 	IssuedCardFormFactor_Virtual IssuedCardFormFactor = "virtual"
 )
 
-// IssuingControls specifies any controls that should apply to the IssuedCard
+// IssuingControls specifies any controls that should apply to the IssuedCard on create
 type IssuingControls struct {
 	// if true, the card closes after the first authorization
 	SingleUse *bool `json:"singleUse,omitempty"`
 
 	VelocityLimits []IssuingVelocityLimit `json:"velocityLimits,omitempty"`
+
+	// restricts card usage by merchant category; when not set, all categories are allowed
+	MerchantCategoryRestrictions *MerchantCategoryRestrictions `json:"merchantCategoryRestrictions,omitempty"`
+
+	// restricts card usage to specific merchants, or blocks specific merchants
+	MerchantRestrictions *MerchantRestrictions `json:"merchantRestrictions,omitempty"`
+
+	// limits card usage to specific days and times
+	AllowedSchedule *AllowedSchedule `json:"allowedSchedule,omitempty"`
+
+	// a spend cutoff; all authorizations after this datetime are declined regardless of other controls
+	ExpiresOn *time.Time `json:"expiresOn,omitempty"`
+}
+
+// IssuedControls specifies the controls applied to an IssuedCard on read, including velocity runtime state
+type IssuedControls struct {
+	// if true, the card closes after the first authorization
+	SingleUse *bool `json:"singleUse,omitempty"`
+
+	VelocityLimits []IssuedVelocityLimit `json:"velocityLimits,omitempty"`
+
+	// restricts card usage by merchant category; when not set, all categories are allowed
+	MerchantCategoryRestrictions *MerchantCategoryRestrictions `json:"merchantCategoryRestrictions,omitempty"`
+
+	// restricts card usage to specific merchants, or blocks specific merchants
+	MerchantRestrictions *MerchantRestrictions `json:"merchantRestrictions,omitempty"`
+
+	// limits card usage to specific days and times
+	AllowedSchedule *AllowedSchedule `json:"allowedSchedule,omitempty"`
+
+	// a spend cutoff; all authorizations after this datetime are declined regardless of other controls
+	ExpiresOn *time.Time `json:"expiresOn,omitempty"`
+}
+
+// UpdateIssuingControls specifies the mutable controls on a PATCH. Each field replaces the entire
+// corresponding value.
+type UpdateIssuingControls struct {
+	// replaces the entire set of velocity limits; nil leaves them unchanged, a non-nil empty slice clears them
+	VelocityLimits *[]IssuingVelocityLimit `json:"velocityLimits,omitempty"`
+
+	// replaces the merchant category restrictions; use SetNull to remove
+	MerchantCategoryRestrictions *Nullable[MerchantCategoryRestrictions] `json:"merchantCategoryRestrictions,omitempty"`
+
+	// replaces the merchant restrictions; use SetNull to remove
+	MerchantRestrictions *Nullable[MerchantRestrictions] `json:"merchantRestrictions,omitempty"`
+
+	// replaces the allowed schedule; use SetNull to remove all schedule restrictions
+	AllowedSchedule *Nullable[AllowedSchedule] `json:"allowedSchedule,omitempty"`
+
+	// a spend cutoff; use SetNull to remove the cutoff
+	ExpiresOn *Nullable[time.Time] `json:"expiresOn,omitempty"`
 }
 
 // IssuingVelocityLimit specifies any spending limits per time Interval that should apply to the IssuedCard
@@ -68,7 +119,36 @@ type IssuingVelocityLimit struct {
 	// the maximum amount in cents that can be spent in a given interval
 	Amount *int32 `json:"amount,omitempty"`
 
+	// the maximum number of transactions allowed in the given interval; at least one of Amount or Count must be set
+	Count *int32 `json:"count,omitempty"`
+
 	Interval *IssuingIntervalLimit `json:"interval,omitempty"`
+}
+
+// IssuedVelocityLimit is a velocity limit with its current runtime state, returned on read
+type IssuedVelocityLimit struct {
+	// the maximum amount in cents that can be spent in a given interval
+	Amount *int32 `json:"amount,omitempty"`
+
+	// the maximum number of transactions allowed in the given interval
+	Count *int32 `json:"count,omitempty"`
+
+	Interval *IssuingIntervalLimit `json:"interval,omitempty"`
+
+	// the amount in cents already spent in the current interval
+	AmountUsed *int32 `json:"amountUsed,omitempty"`
+
+	// the amount in cents remaining in the current interval
+	AmountRemaining *int32 `json:"amountRemaining,omitempty"`
+
+	// the number of transactions already made in the current interval
+	CountUsed *int32 `json:"countUsed,omitempty"`
+
+	// the number of transactions remaining in the current interval
+	CountRemaining *int32 `json:"countRemaining,omitempty"`
+
+	// when the current interval resets; absent for per-transaction limits
+	ResetsOn *time.Time `json:"resetsOn,omitempty"`
 }
 
 // IssuingIntervalLimit specifies the time frame for the IssuingVelocityLimit
@@ -76,6 +156,120 @@ type IssuingIntervalLimit string
 
 const (
 	IssuingIntervalLimit_PerTransaction IssuingIntervalLimit = "per-transaction"
+	IssuingIntervalLimit_Daily          IssuingIntervalLimit = "daily"
+	IssuingIntervalLimit_Weekly         IssuingIntervalLimit = "weekly"
+	IssuingIntervalLimit_Monthly        IssuingIntervalLimit = "monthly"
+)
+
+// IssuingControlsRestrictionMode indicates whether the listed items are the only ones allowed, or the ones to block
+type IssuingControlsRestrictionMode string
+
+const (
+	IssuingControlsRestrictionMode_Allow IssuingControlsRestrictionMode = "allow"
+	IssuingControlsRestrictionMode_Block IssuingControlsRestrictionMode = "block"
+)
+
+// MerchantEntry identifies a merchant by ID, descriptor pattern, or both. At least one of Mid or
+// DescriptorPattern must be set.
+type MerchantEntry struct {
+	// the merchant's unique identifier (ISO 8583 DE42), matched exactly
+	Mid *string `json:"mid,omitempty"`
+
+	// a case-insensitive RE2 regular expression matched against the merchant descriptor (ISO 8583 DE43)
+	DescriptorPattern *string `json:"descriptorPattern,omitempty"`
+
+	// an optional label for this entry
+	Name *string `json:"name,omitempty"`
+}
+
+// MerchantCategoryRestrictions restricts card usage by merchant category
+type MerchantCategoryRestrictions struct {
+	// whether the listed categories are the only ones allowed, or the ones to block
+	Mode IssuingControlsRestrictionMode `json:"mode"`
+
+	// predefined category groups to allow or block
+	Categories []IssuingMerchantCategory `json:"categories,omitempty"`
+
+	// individual merchant category codes (MCCs) to allow or block, for codes not covered by a predefined category
+	CustomMCCs []string `json:"customMCCs,omitempty"`
+
+	// merchants that are exempt from category restrictions regardless of their category
+	ExemptMerchants []MerchantEntry `json:"exemptMerchants,omitempty"`
+}
+
+// MerchantRestrictions restricts card usage to specific merchants, independent of merchant category
+type MerchantRestrictions struct {
+	// whether the listed merchants are the only ones allowed, or the ones to block
+	Mode IssuingControlsRestrictionMode `json:"mode"`
+
+	// the merchants to allow or block
+	Merchants []MerchantEntry `json:"merchants"`
+}
+
+// IssuingScheduleDay is a day of the week used by an AllowedSchedule window
+type IssuingScheduleDay string
+
+const (
+	IssuingScheduleDay_Monday    IssuingScheduleDay = "monday"
+	IssuingScheduleDay_Tuesday   IssuingScheduleDay = "tuesday"
+	IssuingScheduleDay_Wednesday IssuingScheduleDay = "wednesday"
+	IssuingScheduleDay_Thursday  IssuingScheduleDay = "thursday"
+	IssuingScheduleDay_Friday    IssuingScheduleDay = "friday"
+	IssuingScheduleDay_Saturday  IssuingScheduleDay = "saturday"
+	IssuingScheduleDay_Sunday    IssuingScheduleDay = "sunday"
+)
+
+// ScheduleWindow is a window of time during which the card may authorize
+type ScheduleWindow struct {
+	// the days of the week this window applies to
+	Days []IssuingScheduleDay `json:"days"`
+
+	// inclusive window start time in 24-hour HH:MM format
+	StartTime string `json:"startTime"`
+
+	// exclusive window end time in 24-hour HH:MM format; if earlier than StartTime, the window wraps past midnight
+	EndTime string `json:"endTime"`
+}
+
+// AllowedSchedule limits card usage to specific days and times
+type AllowedSchedule struct {
+	// IANA timezone string used to evaluate window boundaries against the authorization time
+	Timezone string `json:"timezone"`
+
+	// time windows during which the card may authorize; any matching window allows the transaction
+	Windows []ScheduleWindow `json:"windows"`
+}
+
+// IssuingMerchantCategory is a predefined merchant category group
+type IssuingMerchantCategory string
+
+const (
+	IssuingMerchantCategory_Advertising          IssuingMerchantCategory = "advertising"
+	IssuingMerchantCategory_Airlines             IssuingMerchantCategory = "airlines"
+	IssuingMerchantCategory_AlcoholAndBars       IssuingMerchantCategory = "alcohol-and-bars"
+	IssuingMerchantCategory_CarRental            IssuingMerchantCategory = "car-rental"
+	IssuingMerchantCategory_Education            IssuingMerchantCategory = "education"
+	IssuingMerchantCategory_Electronics          IssuingMerchantCategory = "electronics"
+	IssuingMerchantCategory_FuelAndGas           IssuingMerchantCategory = "fuel-and-gas"
+	IssuingMerchantCategory_Gambling             IssuingMerchantCategory = "gambling"
+	IssuingMerchantCategory_Groceries            IssuingMerchantCategory = "groceries"
+	IssuingMerchantCategory_GroundTransportation IssuingMerchantCategory = "ground-transportation"
+	IssuingMerchantCategory_HardwareAndHome      IssuingMerchantCategory = "hardware-and-home"
+	IssuingMerchantCategory_Healthcare           IssuingMerchantCategory = "healthcare"
+	IssuingMerchantCategory_LiveEntertainment    IssuingMerchantCategory = "live-entertainment"
+	IssuingMerchantCategory_Lodging              IssuingMerchantCategory = "lodging"
+	IssuingMerchantCategory_Movies               IssuingMerchantCategory = "movies"
+	IssuingMerchantCategory_OfficeSupplies       IssuingMerchantCategory = "office-supplies"
+	IssuingMerchantCategory_Parking              IssuingMerchantCategory = "parking"
+	IssuingMerchantCategory_PersonalCare         IssuingMerchantCategory = "personal-care"
+	IssuingMerchantCategory_ProfessionalServices IssuingMerchantCategory = "professional-services"
+	IssuingMerchantCategory_RestaurantsAndDining IssuingMerchantCategory = "restaurants-and-dining"
+	IssuingMerchantCategory_RetailGeneral        IssuingMerchantCategory = "retail-general"
+	IssuingMerchantCategory_RideshareAndTaxis    IssuingMerchantCategory = "rideshare-and-taxis"
+	IssuingMerchantCategory_SoftwareAndSaas      IssuingMerchantCategory = "software-and-saas"
+	IssuingMerchantCategory_SportsAndRecreation  IssuingMerchantCategory = "sports-and-recreation"
+	IssuingMerchantCategory_Subscriptions        IssuingMerchantCategory = "subscriptions"
+	IssuingMerchantCategory_TravelAgencies       IssuingMerchantCategory = "travel-agencies"
 )
 
 type ListIssuedCardsFilter callArg
@@ -113,6 +307,7 @@ type UpdateIssuedCard struct {
 	Nickname       *string                `json:"nickname,omitempty"`
 	Metadata       map[string]string      `json:"metadata,omitempty"`
 	BillingAddress *AddressPatch          `json:"billingAddress,omitempty"`
+	Controls       *UpdateIssuingControls `json:"controls,omitempty"`
 }
 
 type UpdateIssuedCardState string

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/moovfinancial/moov-go/pkg/moov"
 
@@ -35,6 +36,52 @@ func TestIssuedCardMarshal(t *testing.T) {
 			"metadata": {
 				"program": "rewards"
 			},
+			"controls": {
+				"singleUse": false,
+				"velocityLimits": [
+					{
+						"amount": 10000,
+						"count": 5,
+						"interval": "monthly",
+						"amountUsed": 2500,
+						"amountRemaining": 7500,
+						"countUsed": 1,
+						"countRemaining": 4,
+						"resetsOn": "2023-12-01T00:00:00Z"
+					}
+				],
+				"merchantCategoryRestrictions": {
+					"mode": "block",
+					"categories": ["gambling", "alcohol-and-bars"],
+					"customMCCs": ["5811"],
+					"exemptMerchants": [
+						{
+							"mid": "123456789012345",
+							"descriptorPattern": "(?i)moov",
+							"name": "Moov Financial"
+						}
+					]
+				},
+				"merchantRestrictions": {
+					"mode": "allow",
+					"merchants": [
+						{
+							"descriptorPattern": "(?i)amazon"
+						}
+					]
+				},
+				"allowedSchedule": {
+					"timezone": "America/Denver",
+					"windows": [
+						{
+							"days": ["monday", "tuesday"],
+							"startTime": "09:00",
+							"endTime": "17:00"
+						}
+					]
+				},
+				"expiresOn": "2024-01-01T00:00:00Z"
+			},
 			"createdOn": "2023-11-08T22:06:16Z"
 		}`)
 
@@ -47,6 +94,137 @@ func TestIssuedCardMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "ec7e1848-dc80-4ab0-8827-dd7fc0737b43", card.IssuedCardID)
+
+	require.NotNil(t, card.Controls)
+	require.Len(t, card.Controls.VelocityLimits, 1)
+
+	vl := card.Controls.VelocityLimits[0]
+	require.Equal(t, int32(10000), *vl.Amount)
+	require.Equal(t, int32(5), *vl.Count)
+	require.Equal(t, moov.IssuingIntervalLimit_Monthly, *vl.Interval)
+	require.Equal(t, int32(2500), *vl.AmountUsed)
+	require.Equal(t, int32(7500), *vl.AmountRemaining)
+	require.Equal(t, int32(1), *vl.CountUsed)
+	require.Equal(t, int32(4), *vl.CountRemaining)
+	require.NotNil(t, vl.ResetsOn)
+
+	require.NotNil(t, card.Controls.MerchantCategoryRestrictions)
+	require.Equal(t, moov.IssuingControlsRestrictionMode_Block, card.Controls.MerchantCategoryRestrictions.Mode)
+	require.Equal(t, []moov.IssuingMerchantCategory{
+		moov.IssuingMerchantCategory_Gambling,
+		moov.IssuingMerchantCategory_AlcoholAndBars,
+	}, card.Controls.MerchantCategoryRestrictions.Categories)
+	require.Equal(t, []string{"5811"}, card.Controls.MerchantCategoryRestrictions.CustomMCCs)
+	require.Len(t, card.Controls.MerchantCategoryRestrictions.ExemptMerchants, 1)
+
+	require.NotNil(t, card.Controls.MerchantRestrictions)
+	require.Equal(t, moov.IssuingControlsRestrictionMode_Allow, card.Controls.MerchantRestrictions.Mode)
+
+	require.NotNil(t, card.Controls.AllowedSchedule)
+	require.Equal(t, "America/Denver", card.Controls.AllowedSchedule.Timezone)
+	require.Len(t, card.Controls.AllowedSchedule.Windows, 1)
+	require.Equal(t, []moov.IssuingScheduleDay{
+		moov.IssuingScheduleDay_Monday,
+		moov.IssuingScheduleDay_Tuesday,
+	}, card.Controls.AllowedSchedule.Windows[0].Days)
+
+	require.NotNil(t, card.Controls.ExpiresOn)
+}
+
+func TestCreateIssuedCardMarshal(t *testing.T) {
+	create := moov.CreateIssuedCard{
+		Controls: &moov.IssuingControls{
+			SingleUse: moov.PtrOf(true),
+			VelocityLimits: []moov.IssuingVelocityLimit{
+				{
+					Amount:   moov.PtrOf(int32(10000)),
+					Count:    moov.PtrOf(int32(5)),
+					Interval: moov.PtrOf(moov.IssuingIntervalLimit_Daily),
+				},
+			},
+			MerchantCategoryRestrictions: &moov.MerchantCategoryRestrictions{
+				Mode:            moov.IssuingControlsRestrictionMode_Block,
+				Categories:      []moov.IssuingMerchantCategory{moov.IssuingMerchantCategory_Gambling},
+				CustomMCCs:      []string{"5811"},
+				ExemptMerchants: []moov.MerchantEntry{{Name: moov.PtrOf("Moov Financial")}},
+			},
+			MerchantRestrictions: &moov.MerchantRestrictions{
+				Mode:      moov.IssuingControlsRestrictionMode_Allow,
+				Merchants: []moov.MerchantEntry{{DescriptorPattern: moov.PtrOf("(?i)amazon")}},
+			},
+			AllowedSchedule: &moov.AllowedSchedule{
+				Timezone: "America/Denver",
+				Windows: []moov.ScheduleWindow{
+					{
+						Days:      []moov.IssuingScheduleDay{moov.IssuingScheduleDay_Monday},
+						StartTime: "09:00",
+						EndTime:   "17:00",
+					},
+				},
+			},
+			ExpiresOn: moov.PtrOf(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	out, err := json.Marshal(create)
+	require.NoError(t, err)
+
+	s := string(out)
+	// Verify the request serializes with the API's lowerCamelCase keys (guards against
+	// unnamed/PascalCase JSON tags on the new controls types).
+	for _, key := range []string{
+		`"controls"`,
+		`"velocityLimits"`,
+		`"count":5`,
+		`"merchantCategoryRestrictions"`,
+		`"categories"`,
+		`"customMCCs"`,
+		`"exemptMerchants"`,
+		`"merchantRestrictions"`,
+		`"allowedSchedule"`,
+		`"startTime"`,
+		`"expiresOn"`,
+	} {
+		require.Contains(t, s, key)
+	}
+}
+
+func TestUpdateIssuingControlsMarshal(t *testing.T) {
+	t.Run("unset fields are omitted", func(t *testing.T) {
+		out, err := json.Marshal(moov.UpdateIssuedCard{
+			Controls: &moov.UpdateIssuingControls{},
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{"controls":{}}`, string(out))
+	})
+
+	t.Run("clear velocity limits with empty slice", func(t *testing.T) {
+		out, err := json.Marshal(moov.UpdateIssuingControls{
+			VelocityLimits: &[]moov.IssuingVelocityLimit{},
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{"velocityLimits":[]}`, string(out))
+	})
+
+	t.Run("explicit null removes a field", func(t *testing.T) {
+		out, err := json.Marshal(moov.UpdateIssuingControls{
+			MerchantRestrictions: moov.SetNull[moov.MerchantRestrictions](),
+			ExpiresOn:            moov.SetNull[time.Time](),
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{"merchantRestrictions":null,"expiresOn":null}`, string(out))
+	})
+
+	t.Run("set replaces a field with a value", func(t *testing.T) {
+		out, err := json.Marshal(moov.UpdateIssuingControls{
+			MerchantCategoryRestrictions: moov.Set(moov.MerchantCategoryRestrictions{
+				Mode:       moov.IssuingControlsRestrictionMode_Allow,
+				Categories: []moov.IssuingMerchantCategory{moov.IssuingMerchantCategory_Groceries},
+			}),
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{"merchantCategoryRestrictions":{"mode":"allow","categories":["groceries"]}}`, string(out))
+	})
 }
 
 func TestIssuedCardAuthorizationMarshal(t *testing.T) {


### PR DESCRIPTION
Updates the moov-go SDK to mirror moov-api PR #901 (ISSU-1276), which expands issued-card spend controls on the create, PATCH, and GET endpoints. `IssuedCard.Controls` becomes the new `IssuedControls` read type carrying velocity runtime state (`amountUsed`/`amountRemaining`/`countUsed`/`countRemaining`/`resetsOn`), and `IssuingControls` gains merchant-category, merchant, and allowed-schedule restrictions plus an `expiresOn` cutoff. Adds `UpdateIssuingControls` for PATCH with replace/clear/explicit-null semantics via `Nullable`, plus a velocity `count` dimension and `daily`/`weekly`/`monthly` intervals. Extends the decode test to cover the full `controls` block under `DisallowUnknownFields`, and adds marshal tests asserting create-side JSON keys and the three-state PATCH behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)