### PR TITLE
feat(mv2607): add feePaidBy to CreateTransfer (LEDG-4303)

### DIFF
--- a/pkg/mv2607/transfer_models.go
+++ b/pkg/mv2607/transfer_models.go
@@ -14,6 +14,25 @@ type CreateTransfer struct {
 	Metadata       map[string]string                  `json:"metadata,omitempty"`
 	ForeignID      *string                            `json:"foreignID,omitempty"`
 	LineItems      *moov.CreateTransferLineItems      `json:"lineItems,omitempty"`
+	// FeePaidBy indicates which party bears fees for the transfer, keyed by fee type.
+	FeePaidBy *TransferFeePaidBy `json:"feePaidBy,omitempty"`
+}
+
+// FeePaidBy indicates which party to a money movement bears an incurred fee.
+type FeePaidBy string
+
+// List of FeePaidBy
+const (
+	// FeePaidBy_Source: the source of funds pays the fee.
+	FeePaidBy_Source FeePaidBy = "source"
+	// FeePaidBy_Destination: the destination of funds pays the fee.
+	FeePaidBy_Destination FeePaidBy = "destination"
+)
+
+// TransferFeePaidBy indicates which party bears fees for a transfer, keyed by fee type.
+type TransferFeePaidBy struct {
+	// Payout indicates which party bears the fee for payouts. Defaults to `source`.
+	Payout *FeePaidBy `json:"payout,omitempty"`
 }
 
 type CreateTransferAmountDetails struct {

--- a/pkg/mv2607/transfer_models_test.go
+++ b/pkg/mv2607/transfer_models_test.go
@@ -166,3 +166,47 @@ func TestTransferAmountDetailsSurchargeJSON(t *testing.T) {
 	require.NotNil(t, transfer.Refunds[0].AmountDetails)
 	require.Equal(t, surcharge, *transfer.Refunds[0].AmountDetails.Surcharge)
 }
+
+func TestCreateTransferFeePaidByJSON(t *testing.T) {
+	payout := mv2607.FeePaidBy_Destination
+	create := mv2607.CreateTransfer{
+		Source: moov.CreateTransfer_Source{
+			PaymentMethodID: "source-payment-method",
+		},
+		Destination: moov.CreateTransfer_Destination{
+			PaymentMethodID: "destination-payment-method",
+		},
+		Amount: moov.Amount{
+			Currency: "USD",
+			Value:    100,
+		},
+		FeePaidBy: &mv2607.TransferFeePaidBy{
+			Payout: &payout,
+		},
+	}
+
+	b, err := json.Marshal(create)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"source": {"paymentMethodID": "source-payment-method"},
+		"destination": {"paymentMethodID": "destination-payment-method"},
+		"amount": {"currency": "USD", "value": 100},
+		"facilitatorFee": {},
+		"feePaidBy": {"payout": "destination"}
+	}`, string(b))
+
+	var decoded mv2607.CreateTransfer
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	require.NotNil(t, decoded.FeePaidBy)
+	require.NotNil(t, decoded.FeePaidBy.Payout)
+	require.Equal(t, mv2607.FeePaidBy_Destination, *decoded.FeePaidBy.Payout)
+
+	// feePaidBy is omitted when unset.
+	b, err = json.Marshal(mv2607.CreateTransfer{
+		Source:      moov.CreateTransfer_Source{PaymentMethodID: "s"},
+		Destination: moov.CreateTransfer_Destination{PaymentMethodID: "d"},
+		Amount:      moov.Amount{Currency: "USD", Value: 100},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "feePaidBy")
+}


### PR DESCRIPTION
## What
Adds `feePaidBy` to the 2026.07 (`mv2607`) `CreateTransfer` model so callers can indicate which party bears payout fees.

- `FeePaidBy` enum (`source` / `destination`)
- `TransferFeePaidBy { payout?: FeePaidBy }`
- `CreateTransfer.FeePaidBy *TransferFeePaidBy` (`json:"feePaidBy,omitempty"`)

Matches the moov-api v2026q3 spec (`specification/transfers/models.transfer.tsp`, `specification/common/models.fees.tsp`). JSON round-trip test added.

## Why
The transfers service gates destination-paid payout-fee **netting** (LEDG-4154) on `create.FeePaidBy.GetPayout() == destination`. That field already exists on the internal transfers-client model but had no public-API entry point, so the netting couldn't be triggered by real callers (or exercised end-to-end). This adds the public-API/SDK entry point.

Tracked by **LEDG-4303**; unblocks **LEDG-4157** (checkout disbursement links). CDC-proto parity (`events`) is the remaining half of LEDG-4303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
