### PR TITLE
feat(products): add product taxonomy categories

### DIFF
--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -148,8 +148,9 @@ const (
 	pathImageMetadata = "/accounts/%s/images/%s/metadata"
 	pathPublicImage   = "/images/%s"
 
-	pathProducts = "/accounts/%s/products"
-	pathProduct  = "/accounts/%s/products/%s"
+	pathProducts          = "/accounts/%s/products"
+	pathProduct           = "/accounts/%s/products/%s"
+	pathProductCategories = "/product-categories"
 
 	pathAvatar = "/avatars/%s"
 

--- a/pkg/moov/product_api.go
+++ b/pkg/moov/product_api.go
@@ -2,6 +2,7 @@ package moov
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
 
@@ -70,4 +71,110 @@ func (c Client) DisableProduct(ctx context.Context, accountID string, productID 
 	}
 
 	return CompletedNilOrError(resp)
+}
+
+// CreateProductGeneric creates a product against a specific API version. Version-specific
+// packages (e.g. mv2607) supply their own request and product types.
+func CreateProductGeneric[TRequest any, TProduct any](ctx context.Context, client *Client, version Version, accountID string, product TRequest) (*TProduct, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathProducts, accountID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(product))
+	if err != nil {
+		return nil, err
+	}
+
+	return StartedObjectOrError[TProduct](resp)
+}
+
+// ListProductsGeneric lists products against a specific API version.
+func ListProductsGeneric[TProduct any](ctx context.Context, client *Client, version Version, accountID string, filters ...ProductListFilter) ([]TProduct, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathProducts, accountID),
+		prependArgs(filters, MoovVersion(version), AcceptJson())...)
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedListOrError[TProduct](resp)
+}
+
+// GetProductGeneric retrieves a product against a specific API version.
+func GetProductGeneric[TProduct any](ctx context.Context, client *Client, version Version, accountID string, productID string) (*TProduct, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathProduct, accountID, productID),
+		MoovVersion(version),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TProduct](resp)
+}
+
+// UpdateProductGeneric updates a product against a specific API version.
+func UpdateProductGeneric[TRequest any, TProduct any](ctx context.Context, client *Client, version Version, accountID string, productID string, product TRequest) (*TProduct, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodPut, pathProduct, accountID, productID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(product))
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TProduct](resp)
+}
+
+// DisableProductGeneric disables a product against a specific API version.
+func DisableProductGeneric(ctx context.Context, client *Client, version Version, accountID string, productID string) error {
+	if client == nil {
+		return errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodDelete, pathProduct, accountID, productID),
+		MoovVersion(version),
+		AcceptJson())
+	if err != nil {
+		return err
+	}
+
+	return CompletedNilOrError(resp)
+}
+
+// ListProductCategoriesGeneric returns the full, read-only product taxonomy against a
+// specific API version. TCategories is the version's wrapper type holding the category list.
+// https://docs.moov.io/api/tools/products/list-categories/
+func ListProductCategoriesGeneric[TCategories any](ctx context.Context, client *Client, version Version) (*TCategories, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathProductCategories),
+		MoovVersion(version),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TCategories](resp)
 }

--- a/pkg/moov/product_models.go
+++ b/pkg/moov/product_models.go
@@ -100,3 +100,14 @@ func WithProductTitle(title string) ProductListFilter {
 		return nil
 	})
 }
+
+// WithProductCategory filters products by category. It accepts a category ID at any level of the
+// taxonomy; a product matches when the given category is anywhere in its category's breadcrumb,
+// so filtering by a top-level category returns products in any of its descendants.
+// Requires Version2026_07 or later.
+func WithProductCategory(categoryID string) ProductListFilter {
+	return callBuilderFn(func(call *callBuilder) error {
+		call.params["category"] = categoryID
+		return nil
+	})
+}

--- a/pkg/mv2607/product_api.go
+++ b/pkg/mv2607/product_api.go
@@ -1,0 +1,57 @@
+package mv2607
+
+import (
+	"context"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type ProductClient struct {
+	*moov.Client
+}
+
+func NewProductClient(client *moov.Client) ProductClient {
+	return ProductClient{Client: client}
+}
+
+// CreateProduct creates a new product for the specified account.
+// https://docs.moov.io/api/tools/products/post/
+func (p ProductClient) CreateProduct(ctx context.Context, accountID string, product ProductRequest) (*Product, error) {
+	return moov.CreateProductGeneric[ProductRequest, Product](ctx, p.Client, moov.Version2026_07, accountID, product)
+}
+
+// ListProducts lists products for an account.
+// https://docs.moov.io/api/tools/products/list/
+func (p ProductClient) ListProducts(ctx context.Context, accountID string, filters ...moov.ProductListFilter) ([]Product, error) {
+	return moov.ListProductsGeneric[Product](ctx, p.Client, moov.Version2026_07, accountID, filters...)
+}
+
+// GetProduct retrieves a product by ID.
+// https://docs.moov.io/api/tools/products/get/
+func (p ProductClient) GetProduct(ctx context.Context, accountID string, productID string) (*Product, error) {
+	return moov.GetProductGeneric[Product](ctx, p.Client, moov.Version2026_07, accountID, productID)
+}
+
+// UpdateProduct updates a product and its options.
+// https://docs.moov.io/api/tools/products/put/
+func (p ProductClient) UpdateProduct(ctx context.Context, accountID string, productID string, product ProductRequest) (*Product, error) {
+	return moov.UpdateProductGeneric[ProductRequest, Product](ctx, p.Client, moov.Version2026_07, accountID, productID, product)
+}
+
+// DisableProduct disables a product by ID.
+// The product will no longer be available, but will remain in the system for historical and reporting purposes.
+// https://docs.moov.io/api/tools/products/delete/
+func (p ProductClient) DisableProduct(ctx context.Context, accountID string, productID string) error {
+	return moov.DisableProductGeneric(ctx, p.Client, moov.Version2026_07, accountID, productID)
+}
+
+// ListProductCategories returns the full, read-only list of product categories from the
+// product taxonomy.
+func (p ProductClient) ListProductCategories(ctx context.Context) ([]ProductCategory, error) {
+	categories, err := moov.ListProductCategoriesGeneric[ProductCategories](ctx, p.Client, moov.Version2026_07)
+	if err != nil {
+		return nil, err
+	}
+
+	return categories.Categories, nil
+}

--- a/pkg/mv2607/product_api_test.go
+++ b/pkg/mv2607/product_api_test.go
@@ -48,17 +48,20 @@ const productWithCategoryJSON = `{
 
 func TestCreateProduct(t *testing.T) {
 	var (
-		method  string
-		path    string
-		version string
-		body    map[string]any
+		method    string
+		path      string
+		version   string
+		body      map[string]any
+		decodeErr error
 	)
 
+	// The handler runs on its own goroutine, so it records what it saw rather than
+	// asserting: require.* calls t.FailNow, which is only valid on the test goroutine.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		method = r.Method
 		path = r.URL.Path
 		version = r.Header.Get(moov.VersionHeader)
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		decodeErr = json.NewDecoder(r.Body).Decode(&body)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -77,6 +80,7 @@ func TestCreateProduct(t *testing.T) {
 		CategoryID: moov.PtrOf("413"),
 	})
 	require.NoError(t, err)
+	require.NoError(t, decodeErr)
 
 	require.Equal(t, http.MethodPost, method)
 	require.Equal(t, "/accounts/account-123/products", path)
@@ -104,17 +108,20 @@ func TestProductRequestOmitsCategoryID(t *testing.T) {
 
 func TestUpdateProduct(t *testing.T) {
 	var (
-		method  string
-		path    string
-		version string
-		body    map[string]any
+		method    string
+		path      string
+		version   string
+		body      map[string]any
+		decodeErr error
 	)
 
+	// The handler runs on its own goroutine, so it records what it saw rather than
+	// asserting: require.* calls t.FailNow, which is only valid on the test goroutine.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		method = r.Method
 		path = r.URL.Path
 		version = r.Header.Get(moov.VersionHeader)
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		decodeErr = json.NewDecoder(r.Body).Decode(&body)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(productWithCategoryJSON))
@@ -129,6 +136,7 @@ func TestUpdateProduct(t *testing.T) {
 		CategoryID: moov.PtrOf("413"),
 	})
 	require.NoError(t, err)
+	require.NoError(t, decodeErr)
 
 	require.Equal(t, http.MethodPut, method)
 	require.Equal(t, "/accounts/account-123/products/ec7e1848-dc80-4ab0-8827-dd7fc0737b43", path)

--- a/pkg/mv2607/product_api_test.go
+++ b/pkg/mv2607/product_api_test.go
@@ -1,0 +1,266 @@
+package mv2607_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2607"
+)
+
+// newProductTestClient points a client at srv so tests can assert on the raw request.
+func newProductTestClient(t *testing.T, srv *httptest.Server) mv2607.ProductClient {
+	t.Helper()
+
+	client, err := moov.NewClient(
+		moov.WithCredentials(moov.Credentials{PublicKey: "pk", SecretKey: "sk"}),
+		moov.WithMoovURLScheme("http"),
+	)
+	require.NoError(t, err)
+	client.Credentials.Host = strings.TrimPrefix(srv.URL, "http://")
+
+	return mv2607.NewProductClient(client)
+}
+
+const productWithCategoryJSON = `{
+	"productID": "ec7e1848-dc80-4ab0-8827-dd7fc0737b43",
+	"title": "Cold Brew",
+	"basePrice": {
+		"currency": "USD",
+		"valueDecimal": "4.50"
+	},
+	"category": {
+		"categoryID": "413",
+		"name": "Beverages",
+		"fullName": "Food, Beverages & Tobacco > Beverages",
+		"level": 2,
+		"parentID": "412"
+	},
+	"createdOn": "2026-06-18T12:00:00Z",
+	"updatedOn": "2026-06-18T12:00:00Z"
+}`
+
+func TestCreateProduct(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+		body    map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(productWithCategoryJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	created, err := products.CreateProduct(context.Background(), "account-123", mv2607.ProductRequest{
+		Title: "Cold Brew",
+		BasePrice: moov.AmountDecimal{
+			Currency:     "USD",
+			ValueDecimal: "4.50",
+		},
+		CategoryID: moov.PtrOf("413"),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPost, method)
+	require.Equal(t, "/accounts/account-123/products", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+	require.Equal(t, "413", body["categoryID"])
+
+	require.NotNil(t, created)
+	require.Equal(t, "Cold Brew", created.Title)
+	require.NotNil(t, created.Category)
+	require.Equal(t, "413", created.Category.CategoryID)
+	require.Equal(t, "Beverages", created.Category.Name)
+	require.Equal(t, "Food, Beverages & Tobacco > Beverages", created.Category.FullName)
+	require.Equal(t, int32(2), created.Category.Level)
+	require.Equal(t, moov.PtrOf("412"), created.Category.ParentID)
+}
+
+func TestProductRequestOmitsCategoryID(t *testing.T) {
+	b, err := json.Marshal(mv2607.ProductRequest{
+		Title:     "Cold Brew",
+		BasePrice: moov.AmountDecimal{Currency: "USD", ValueDecimal: "4.50"},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"categoryID"`)
+}
+
+func TestUpdateProduct(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+		body    map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(productWithCategoryJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	updated, err := products.UpdateProduct(context.Background(), "account-123", "ec7e1848-dc80-4ab0-8827-dd7fc0737b43", mv2607.ProductRequest{
+		Title:      "Cold Brew",
+		BasePrice:  moov.AmountDecimal{Currency: "USD", ValueDecimal: "4.50"},
+		CategoryID: moov.PtrOf("413"),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPut, method)
+	require.Equal(t, "/accounts/account-123/products/ec7e1848-dc80-4ab0-8827-dd7fc0737b43", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+	require.Equal(t, "413", body["categoryID"])
+
+	require.NotNil(t, updated)
+	require.NotNil(t, updated.Category)
+	require.Equal(t, "413", updated.Category.CategoryID)
+}
+
+func TestGetProduct(t *testing.T) {
+	var version string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		version = r.Header.Get(moov.VersionHeader)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(productWithCategoryJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	got, err := products.GetProduct(context.Background(), "account-123", "ec7e1848-dc80-4ab0-8827-dd7fc0737b43")
+	require.NoError(t, err)
+
+	require.Equal(t, moov.Version2026_07.String(), version)
+	require.NotNil(t, got.Category)
+	require.Equal(t, "Beverages", got.Category.Name)
+}
+
+func TestListProductsFilteredByCategory(t *testing.T) {
+	var (
+		path    string
+		query   string
+		version string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		query = r.URL.Query().Get("category")
+		version = r.Header.Get(moov.VersionHeader)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[" + productWithCategoryJSON + "]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	list, err := products.ListProducts(context.Background(), "account-123", moov.WithProductCategory("412"))
+	require.NoError(t, err)
+
+	require.Equal(t, "/accounts/account-123/products", path)
+	require.Equal(t, "412", query)
+	require.Equal(t, moov.Version2026_07.String(), version)
+
+	require.Len(t, list, 1)
+	require.NotNil(t, list[0].Category)
+	require.Equal(t, "413", list[0].Category.CategoryID)
+}
+
+func TestListProductCategories(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"categories": [
+				{
+					"categoryID": "412",
+					"name": "Food, Beverages & Tobacco",
+					"fullName": "Food, Beverages & Tobacco",
+					"level": 1
+				},
+				{
+					"categoryID": "413",
+					"name": "Beverages",
+					"fullName": "Food, Beverages & Tobacco > Beverages",
+					"level": 2,
+					"parentID": "412"
+				}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	categories, err := products.ListProductCategories(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, method)
+	require.Equal(t, "/product-categories", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+
+	require.Len(t, categories, 2)
+	require.Equal(t, "412", categories[0].CategoryID)
+	require.Equal(t, int32(1), categories[0].Level)
+	require.Nil(t, categories[0].ParentID)
+	require.Equal(t, "413", categories[1].CategoryID)
+	require.Equal(t, moov.PtrOf("412"), categories[1].ParentID)
+}
+
+func TestDisableProduct(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	products := newProductTestClient(t, srv)
+
+	require.NoError(t, products.DisableProduct(context.Background(), "account-123", "ec7e1848-dc80-4ab0-8827-dd7fc0737b43"))
+
+	require.Equal(t, http.MethodDelete, method)
+	require.Equal(t, "/accounts/account-123/products/ec7e1848-dc80-4ab0-8827-dd7fc0737b43", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+}

--- a/pkg/mv2607/product_models.go
+++ b/pkg/mv2607/product_models.go
@@ -1,0 +1,44 @@
+package mv2607
+
+import "github.com/moovfinancial/moov-go/pkg/moov"
+
+// Product is a good or service offered by a merchant, including the product taxonomy
+// category associated with it.
+type Product struct {
+	moov.Product
+
+	// Category is the product taxonomy category associated with the product, if any.
+	Category *ProductCategory `json:"category,omitempty"`
+}
+
+// ProductRequest is a request to create or update a product.
+type ProductRequest struct {
+	Title        string                          `json:"title"`
+	Description  *string                         `json:"description,omitempty"`
+	BasePrice    moov.AmountDecimal              `json:"basePrice"`
+	Images       []moov.AssignProductImage       `json:"images,omitempty"`
+	OptionGroups []moov.CreateProductOptionGroup `json:"optionGroups,omitempty"`
+
+	// CategoryID is the ID of a product taxonomy category to associate with the product.
+	CategoryID *string `json:"categoryID,omitempty"`
+}
+
+// ProductCategory is a product category from the product taxonomy.
+type ProductCategory struct {
+	// CategoryID is the unique identifier for the category.
+	CategoryID string `json:"categoryID"`
+	// Name is the short display name of the category, e.g. "Beverages".
+	Name string `json:"name"`
+	// FullName is the full taxonomy path name of the category,
+	// e.g. "Food, Beverages & Tobacco > Beverages".
+	FullName string `json:"fullName"`
+	// Level is the depth of the category in the taxonomy tree (1 = top-level).
+	Level int32 `json:"level"`
+	// ParentID is the identifier of the parent category. Absent for top-level categories.
+	ParentID *string `json:"parentID,omitempty"`
+}
+
+// ProductCategories is a list of product categories from the product taxonomy.
+type ProductCategories struct {
+	Categories []ProductCategory `json:"categories"`
+}


### PR DESCRIPTION
Mirrors the moov-api product taxonomy work (DASH-112) in the Go SDK.

The API gates these behind `@added(v2026q3)` in TypeSpec (`specification/products/models.category.tsp`, `models.product.tsp`, `routes.taxonomy.tsp`), so they're exposed through the versioned `mv2607` package rather than the unversioned `moov` client — consistent with how transfers, sweeps, and deposit views handle versioned surfaces.

## What's added

**`pkg/moov`** — version-agnostic generics, following the existing `*Generic` pattern:

- `CreateProductGeneric`, `ListProductsGeneric`, `GetProductGeneric`, `UpdateProductGeneric`, `DisableProductGeneric`, `ListProductCategoriesGeneric` — each takes a `Version` and applies the `MoovVersion(version)` decorator.
- `WithProductCategory` list filter (the `category` query param, also `@added(v2026q3)`).
- `pathProductCategories = "/product-categories"`.

The existing unversioned `Client` product methods are untouched.

**`pkg/mv2607`** — the versioned surface:

- `ProductClient` / `NewProductClient`, wrapping all six generics at `moov.Version2026_07`.
- `ProductRequest` with `CategoryID *string`.
- `Product` (embeds `moov.Product`) with `Category *ProductCategory`.
- `ProductCategory` (`categoryID`, `name`, `fullName`, `level`, `parentID`) and `ProductCategories`.
- `ListProductCategories` unwraps the `{"categories": [...]}` envelope and returns `[]ProductCategory`.

## Testing

`pkg/mv2607/product_api_test.go` uses `httptest` to assert on the wire format: the `X-Moov-Version` header is `v2026.07.00` on every call, `categoryID` is present on POST/PUT bodies and omitted when nil, `category` decodes on create/get/list responses, the `category` query param is set, and `/product-categories` returns the unwrapped list with `parentID` nil for top-level categories.

Verified locally:

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- The CI lint job (`make check` with `SKIP_TESTS=yes`, i.e. moov-io/infra `lint-project.sh`) — govulncheck clean, golangci-lint **0 issues**.
- `go test ./pkg/mv2607/...` — passes.
- Full `go test ./...` fails only in integration/example tests, every one with `api credentials not set`; no credentials locally. CI supplies these via secrets, so that path is unverified on my side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)