### PR TITLE
feat(avatars): add GetAvatar SDK method

### DIFF
--- a/pkg/moov/avatar_api.go
+++ b/pkg/moov/avatar_api.go
@@ -34,7 +34,7 @@ func (c Client) GetAvatar(ctx context.Context, uniqueID string) ([]byte, string,
 	}
 
 	contentType := ""
-	if hcr, ok := resp.(HttpCallResponse); ok {
+	if hcr, ok := resp.(*httpCallResponse); ok {
 		contentType = hcr.ContentType()
 	}
 	return buf.Bytes(), contentType, nil

--- a/pkg/moov/avatar_api.go
+++ b/pkg/moov/avatar_api.go
@@ -1,11 +1,44 @@
 package moov
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net/http"
 )
+
+// GetAvatar retrieves an avatar image for an account and returns the raw image
+// bytes along with the image's content type (e.g. "image/png"). Unlike the
+// write endpoints, uniqueID accepts any unique ID associated with an account
+// such as accountID, representativeID, routing number, or userID. The response
+// is a user-uploaded avatar if one exists, otherwise the enriched avatar or an
+// account-type-aware fallback icon.
+// https://docs.moov.io/api/enrichment/form-shortening/avatars/get/
+func (c Client) GetAvatar(ctx context.Context, uniqueID string) ([]byte, string, error) {
+	if uniqueID == "" {
+		return nil, "", errors.New("uniqueID cannot be empty")
+	}
+
+	resp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathAvatar, uniqueID),
+		MoovVersion(Version2026_07),
+		AcceptContentType("image/*"))
+	if err != nil {
+		return nil, "", err
+	}
+
+	buf, err := CompletedObjectOrError[bytes.Buffer](resp)
+	if err != nil {
+		return nil, "", err
+	}
+
+	contentType := ""
+	if hcr, ok := resp.(HttpCallResponse); ok {
+		contentType = hcr.ContentType()
+	}
+	return buf.Bytes(), contentType, nil
+}
 
 // UploadAvatar uploads a user avatar image for an account.
 // The accountID is used as the uniqueID; only accountID values are accepted for

--- a/pkg/moov/avatar_test.go
+++ b/pkg/moov/avatar_test.go
@@ -29,6 +29,13 @@ func Test_Avatars(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("get avatar", func(t *testing.T) {
+		img, contentType, err := mc.GetAvatar(ctx, accountID)
+		require.NoError(t, err)
+		require.NotEmpty(t, img)
+		require.Contains(t, contentType, "image/")
+	})
+
 	t.Run("delete avatar", func(t *testing.T) {
 		err := mc.DeleteAvatar(ctx, accountID)
 

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -86,7 +86,6 @@ type HttpCallResponse interface {
 
 	RequestId() string
 	StatusCode() int
-	ContentType() string
 }
 
 type httpCallResponse struct {
@@ -160,10 +159,10 @@ func (r *httpCallResponse) StatusCode() int {
 }
 
 func (r *httpCallResponse) ContentType() string {
-	if r.resp != nil {
-		return r.resp.Header.Get("Content-Type")
+	if r == nil || r.resp == nil {
+		return ""
 	}
-	return ""
+	return r.resp.Header.Get("Content-Type")
 }
 
 func (r *httpCallResponse) RequestId() string {

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -86,6 +86,7 @@ type HttpCallResponse interface {
 
 	RequestId() string
 	StatusCode() int
+	ContentType() string
 }
 
 type httpCallResponse struct {
@@ -156,6 +157,13 @@ func (r *httpCallResponse) StatusCode() int {
 		return r.resp.StatusCode
 	}
 	return 0
+}
+
+func (r *httpCallResponse) ContentType() string {
+	if r.resp != nil {
+		return r.resp.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 func (r *httpCallResponse) RequestId() string {


### PR DESCRIPTION
## What

Adds `GetAvatar` to the Go SDK, completing the avatar CRUD surface alongside the existing `UploadAvatar` and `DeleteAvatar` methods (added in #352).

```go
func (c Client) GetAvatar(ctx context.Context, uniqueID string) (image []byte, contentType string, err error)
```

## Details

- The `GET /avatars/{uniqueID}` endpoint returns raw image bytes (`image/*`), not JSON. `GetAvatar` returns the image `[]byte` and the response content type (e.g. `image/png`) so callers can distinguish PNG/JPEG/WebP — user-uploaded avatars are normalized to PNG, but enriched/fallback images may be other formats.
- To expose the content type, added a `ContentType()` accessor to the `HttpCallResponse` interface and its implementation, matching the existing `RequestId()`/`StatusCode()` style.
- Binary body is read via the existing `bytes.Buffer` response path (same pattern as `GetStatementPDF`).
- Unlike the write endpoints (accountID only), the read endpoint accepts any unique ID associated with an account — accountID, representativeID, routing number, or userID — so the parameter is named `uniqueID`.

## Testing

- Extended `Test_Avatars` with a `get avatar` subtest asserting non-empty bytes and an `image/` content type.
- `go build` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)