### PR TITLE
feat(underwriting): add send-funds.wire rail [v2026.07.00]

### DIFF
--- a/pkg/moov/capabilities_models.go
+++ b/pkg/moov/capabilities_models.go
@@ -40,6 +40,7 @@ const (
 	CapabilityName_SendFundsRTP         CapabilityName = "send-funds.rtp"
 	CapabilityName_SendFundsPushToCard  CapabilityName = "send-funds.push-to-card"
 	CapabilityName_SendFundsInstantBank CapabilityName = "send-funds.instant-bank"
+	CapabilityName_SendFundsWire        CapabilityName = "send-funds.wire"
 )
 
 // Capability Describes an action or set of actions that an account is permitted to perform.

--- a/pkg/moov/underwriting_api.go
+++ b/pkg/moov/underwriting_api.go
@@ -45,6 +45,9 @@ func GetUnderwritingGeneric[TUnderwriting any](ctx context.Context, client *Clie
 	if client == nil {
 		return nil, errors.New("client is nil")
 	}
+	if accountID == "" {
+		return nil, errors.New("accountID is required")
+	}
 
 	resp, err := client.CallHttp(ctx,
 		Endpoint(http.MethodGet, pathUnderwriting, accountID),
@@ -63,6 +66,9 @@ func GetUnderwritingGeneric[TUnderwriting any](ctx context.Context, client *Clie
 func UpsertUnderwritingGeneric[TRequest any, TUnderwriting any](ctx context.Context, client *Client, version Version, accountID string, underwriting TRequest) (*TUnderwriting, error) {
 	if client == nil {
 		return nil, errors.New("client is nil")
+	}
+	if accountID == "" {
+		return nil, errors.New("accountID is required")
 	}
 
 	resp, err := client.CallHttp(ctx,

--- a/pkg/moov/underwriting_api.go
+++ b/pkg/moov/underwriting_api.go
@@ -2,6 +2,7 @@ package moov
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
 
@@ -35,6 +36,45 @@ func (uc UnderwritingClient[T, V]) Upsert(ctx context.Context, client Client, ac
 	}
 
 	return CompletedObjectOrError[V](httpResp)
+}
+
+// GetUnderwritingGeneric returns the underwriting information for the given account
+// against a specific API version. Version-specific packages (e.g. mv2607) supply their
+// own underwriting type.
+func GetUnderwritingGeneric[TUnderwriting any](ctx context.Context, client *Client, version Version, accountID string) (*TUnderwriting, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathUnderwriting, accountID),
+		MoovVersion(version),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TUnderwriting](resp)
+}
+
+// UpsertUnderwritingGeneric adds or updates underwriting information for the given
+// account against a specific API version. Version-specific packages (e.g. mv2607)
+// supply their own request and underwriting types.
+func UpsertUnderwritingGeneric[TRequest any, TUnderwriting any](ctx context.Context, client *Client, version Version, accountID string, underwriting TRequest) (*TUnderwriting, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+
+	resp, err := client.CallHttp(ctx,
+		Endpoint(http.MethodPost, pathUnderwriting, accountID),
+		MoovVersion(version),
+		AcceptJson(),
+		JsonBody(underwriting))
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[TUnderwriting](resp)
 }
 
 // Legacy

--- a/pkg/mv2607/underwriting_api.go
+++ b/pkg/mv2607/underwriting_api.go
@@ -1,0 +1,28 @@
+package mv2607
+
+import (
+	"context"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type UnderwritingClient struct {
+	*moov.Client
+}
+
+func NewUnderwritingClient(client *moov.Client) UnderwritingClient {
+	return UnderwritingClient{Client: client}
+}
+
+// GetUnderwriting returns the underwriting information for the given account.
+// https://docs.moov.io/guides/accounts/requirements/underwriting/
+func (u UnderwritingClient) GetUnderwriting(ctx context.Context, accountID string) (*Underwriting, error) {
+	return moov.GetUnderwritingGeneric[Underwriting](ctx, u.Client, moov.Version2026_07, accountID)
+}
+
+// UpsertUnderwriting adds or updates underwriting information for the given account.
+// Returns the underwriting information for the account.
+// https://docs.moov.io/guides/accounts/requirements/underwriting/
+func (u UnderwritingClient) UpsertUnderwriting(ctx context.Context, accountID string, underwriting UpsertUnderwriting) (*Underwriting, error) {
+	return moov.UpsertUnderwritingGeneric[UpsertUnderwriting, Underwriting](ctx, u.Client, moov.Version2026_07, accountID, underwriting)
+}

--- a/pkg/mv2607/underwriting_api_test.go
+++ b/pkg/mv2607/underwriting_api_test.go
@@ -147,6 +147,27 @@ func TestGetUnderwriting(t *testing.T) {
 	require.Equal(t, moov.PtrOf(mv2607.MonthlyVolumeRange1M5M), actual.SendFunds.Wire.EstimatedActivity.MonthlyVolumeRange)
 }
 
+// An empty accountID would produce /accounts//underwriting, so both calls must fail
+// before reaching the network.
+func TestUnderwritingRequiresAccountID(t *testing.T) {
+	called := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	_, err := underwriting.GetUnderwriting(context.Background(), "")
+	require.EqualError(t, err, "accountID is required")
+
+	_, err = underwriting.UpsertUnderwriting(context.Background(), "", mv2607.UpsertUnderwriting{})
+	require.EqualError(t, err, "accountID is required")
+
+	require.False(t, called, "no request should reach the server")
+}
+
 // SendFunds must not emit a wire key when the rail isn't set, so pre-v2026.07 shapes
 // round-trip unchanged.
 func TestSendFundsOmitsWireWhenUnset(t *testing.T) {

--- a/pkg/mv2607/underwriting_api_test.go
+++ b/pkg/mv2607/underwriting_api_test.go
@@ -1,0 +1,158 @@
+package mv2607_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2607"
+)
+
+// newUnderwritingTestClient points a client at srv so tests can assert on the raw request.
+func newUnderwritingTestClient(t *testing.T, srv *httptest.Server) mv2607.UnderwritingClient {
+	t.Helper()
+
+	client, err := moov.NewClient(
+		moov.WithCredentials(moov.Credentials{PublicKey: "pk", SecretKey: "sk"}),
+		moov.WithMoovURLScheme("http"),
+	)
+	require.NoError(t, err)
+	client.Credentials.Host = strings.TrimPrefix(srv.URL, "http://")
+
+	return mv2607.NewUnderwritingClient(client)
+}
+
+const underwritingWithWireJSON = `{
+	"geographicReach": "us-only",
+	"sendFunds": {
+		"instantBank": {
+			"estimatedActivity": {
+				"monthlyVolumeRange": "10k-50k"
+			}
+		},
+		"wire": {
+			"estimatedActivity": {
+				"averageTransactionAmount": 250000,
+				"maximumTransactionAmount": 1000000,
+				"monthlyVolumeRange": "1m-5m"
+			}
+		}
+	}
+}`
+
+func TestUpsertUnderwriting(t *testing.T) {
+	var (
+		method    string
+		path      string
+		version   string
+		body      map[string]any
+		decodeErr error
+	)
+
+	// The handler runs on its own goroutine, so it records what it saw rather than
+	// asserting: require.* calls t.FailNow, which is only valid on the test goroutine.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+		decodeErr = json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(underwritingWithWireJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	actual, err := underwriting.UpsertUnderwriting(context.Background(), "account-123", mv2607.UpsertUnderwriting{
+		GeographicReach: moov.PtrOf(mv2607.GeographicReachUsOnly),
+		SendFunds: &mv2607.SendFunds{
+			InstantBank: &mv2607.SendFundsInstantBank{
+				EstimatedActivity: &mv2607.EstimatedActivity{
+					MonthlyVolumeRange: moov.PtrOf(mv2607.MonthlyVolumeRange10K50K),
+				},
+			},
+			Wire: &mv2607.SendFundsWire{
+				EstimatedActivity: &mv2607.EstimatedActivity{
+					AverageTransactionAmount: moov.PtrOf(int64(250_000)),
+					MaximumTransactionAmount: moov.PtrOf(int64(1_000_000)),
+					MonthlyVolumeRange:       moov.PtrOf(mv2607.MonthlyVolumeRange1M5M),
+				},
+			},
+		},
+		SubmissionIntent: moov.PtrOf(mv2607.SubmissionIntentSubmit),
+	})
+	require.NoError(t, err)
+	require.NoError(t, decodeErr)
+
+	require.Equal(t, http.MethodPost, method)
+	require.Equal(t, "/accounts/account-123/underwriting", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+
+	sendFunds, ok := body["sendFunds"].(map[string]any)
+	require.True(t, ok)
+	wire, ok := sendFunds["wire"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"averageTransactionAmount": float64(250_000),
+		"maximumTransactionAmount": float64(1_000_000),
+		"monthlyVolumeRange":       "1m-5m",
+	}, wire["estimatedActivity"])
+
+	require.NotNil(t, actual)
+	require.NotNil(t, actual.SendFunds)
+	require.NotNil(t, actual.SendFunds.Wire)
+	require.Equal(t, moov.PtrOf(mv2607.MonthlyVolumeRange1M5M), actual.SendFunds.Wire.EstimatedActivity.MonthlyVolumeRange)
+	require.Equal(t, moov.PtrOf(int64(250_000)), actual.SendFunds.Wire.EstimatedActivity.AverageTransactionAmount)
+	require.Equal(t, moov.PtrOf(int64(1_000_000)), actual.SendFunds.Wire.EstimatedActivity.MaximumTransactionAmount)
+}
+
+func TestGetUnderwriting(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(underwritingWithWireJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	actual, err := underwriting.GetUnderwriting(context.Background(), "account-123")
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, method)
+	require.Equal(t, "/accounts/account-123/underwriting", path)
+	require.Equal(t, moov.Version2026_07.String(), version)
+
+	require.NotNil(t, actual)
+	require.Equal(t, moov.PtrOf(mv2607.GeographicReachUsOnly), actual.GeographicReach)
+	require.NotNil(t, actual.SendFunds)
+	require.NotNil(t, actual.SendFunds.InstantBank)
+	require.NotNil(t, actual.SendFunds.Wire)
+	require.Equal(t, moov.PtrOf(mv2607.MonthlyVolumeRange1M5M), actual.SendFunds.Wire.EstimatedActivity.MonthlyVolumeRange)
+}
+
+// SendFunds must not emit a wire key when the rail isn't set, so pre-v2026.07 shapes
+// round-trip unchanged.
+func TestSendFundsOmitsWireWhenUnset(t *testing.T) {
+	b, err := json.Marshal(mv2607.SendFunds{
+		InstantBank: &mv2607.SendFundsInstantBank{},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"wire"`)
+}

--- a/pkg/mv2607/underwriting_integration_test.go
+++ b/pkg/mv2607/underwriting_integration_test.go
@@ -1,0 +1,90 @@
+package mv2607_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2607"
+)
+
+func TestUpsertUnderwriting_Integration(t *testing.T) {
+	client := newIntegrationClient(t)
+	ctx := context.Background()
+
+	created, started, err := client.CreateAccount(ctx, moov.CreateAccount{
+		Type: moov.AccountType_Business,
+		Profile: moov.CreateProfile{
+			Business: &moov.CreateBusinessProfile{
+				Name:        "moov-go underwriting SDK test",
+				Type:        moov.BusinessType_Llc,
+				Description: "moov-go SDK underwriting integration test",
+				IndustryCodes: &moov.IndustryCodes{
+					Mcc:   "6012",
+					Naics: "522110",
+					Sic:   "6021",
+				},
+				Industry: "electronics-appliances",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	account := created
+	if account == nil {
+		account = started
+	}
+	require.NotNil(t, account)
+
+	t.Cleanup(func() {
+		_ = client.DisconnectAccount(context.Background(), account.AccountID)
+	})
+
+	underwriting := mv2607.NewUnderwritingClient(client)
+
+	upsert := mv2607.UpsertUnderwriting{
+		GeographicReach:   moov.PtrOf(mv2607.GeographicReachUsOnly),
+		BusinessPresence:  moov.PtrOf(mv2607.BusinessPresenceHomeBased),
+		PendingLitigation: moov.PtrOf(mv2607.PendingLitigationNone),
+		VolumeShareByCustomerType: &mv2607.VolumeShareByCustomerType{
+			Business: moov.PtrOf(70),
+			Consumer: moov.PtrOf(30),
+			P2P:      moov.PtrOf(0),
+		},
+		SendFunds: &mv2607.SendFunds{
+			Ach: &mv2607.SendFundsAch{
+				EstimatedActivity: &mv2607.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2607.MonthlyVolumeRangeUnder10K)},
+			},
+			InstantBank: &mv2607.SendFundsInstantBank{
+				EstimatedActivity: &mv2607.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2607.MonthlyVolumeRangeUnder10K)},
+			},
+			Wire: &mv2607.SendFundsWire{
+				EstimatedActivity: &mv2607.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2607.MonthlyVolumeRange1M5M)},
+			},
+		},
+		SubmissionIntent: moov.PtrOf(mv2607.SubmissionIntentWait),
+	}
+
+	t.Run("upsert", func(t *testing.T) {
+		actual, err := underwriting.UpsertUnderwriting(ctx, account.AccountID, upsert)
+		require.NoError(t, err)
+
+		require.NotNil(t, actual)
+		require.Equal(t, upsert.GeographicReach, actual.GeographicReach)
+		require.Equal(t, upsert.BusinessPresence, actual.BusinessPresence)
+		require.Equal(t, upsert.PendingLitigation, actual.PendingLitigation)
+		require.Equal(t, upsert.VolumeShareByCustomerType, actual.VolumeShareByCustomerType)
+		require.Equal(t, upsert.SendFunds, actual.SendFunds)
+	})
+
+	t.Run("get", func(t *testing.T) {
+		actual, err := underwriting.GetUnderwriting(ctx, account.AccountID)
+		require.NoError(t, err)
+
+		require.NotNil(t, actual)
+		require.Equal(t, upsert.GeographicReach, actual.GeographicReach)
+		require.Equal(t, upsert.SendFunds, actual.SendFunds)
+	})
+}

--- a/pkg/mv2607/underwriting_models.go
+++ b/pkg/mv2607/underwriting_models.go
@@ -1,0 +1,214 @@
+package mv2607
+
+import "github.com/moovfinancial/moov-go/pkg/moov"
+
+// UpsertUnderwriting is the v2026.07 underwriting request body.
+type UpsertUnderwriting struct {
+	GeographicReach           *GeographicReach           `json:"geographicReach,omitempty"`
+	BusinessPresence          *BusinessPresence          `json:"businessPresence,omitempty"`
+	PendingLitigation         *PendingLitigation         `json:"pendingLitigation,omitempty"`
+	VolumeShareByCustomerType *VolumeShareByCustomerType `json:"volumeShareByCustomerType,omitempty"`
+	CollectFunds              *CollectFunds              `json:"collectFunds,omitempty"`
+	MoneyTransfer             *MoneyTransfer             `json:"moneyTransfer,omitempty"`
+	SendFunds                 *SendFunds                 `json:"sendFunds,omitempty"`
+	SubmissionIntent          *SubmissionIntent          `json:"submissionIntent,omitempty"`
+}
+
+// Underwriting is the v2026.07 underwriting response. The legacy fields are only
+// returned for accounts that submitted underwriting through the pre-versioned API, so
+// they're optional.
+type Underwriting struct {
+	AverageTransactionSize          *int64                       `json:"averageTransactionSize,omitempty"`
+	MaxTransactionSize              *int64                       `json:"maxTransactionSize,omitempty"`
+	AverageMonthlyTransactionVolume *int64                       `json:"averageMonthlyTransactionVolume,omitempty"`
+	VolumeByCustomerType            *moov.VolumeByCustomerType   `json:"volumeByCustomerType,omitempty"`
+	CardVolumeDistribution          *moov.CardVolumeDistribution `json:"cardVolumeDistribution,omitempty"`
+	Fulfillment                     *moov.Fulfillment            `json:"fulfillment,omitempty"`
+
+	GeographicReach           *GeographicReach           `json:"geographicReach,omitempty"`
+	BusinessPresence          *BusinessPresence          `json:"businessPresence,omitempty"`
+	PendingLitigation         *PendingLitigation         `json:"pendingLitigation,omitempty"`
+	VolumeShareByCustomerType *VolumeShareByCustomerType `json:"volumeShareByCustomerType,omitempty"`
+	CollectFunds              *CollectFunds              `json:"collectFunds,omitempty"`
+	MoneyTransfer             *MoneyTransfer             `json:"moneyTransfer,omitempty"`
+	SendFunds                 *SendFunds                 `json:"sendFunds,omitempty"`
+}
+
+type GeographicReach string
+
+const (
+	GeographicReachInternationalOnly  GeographicReach = "international-only"
+	GeographicReachUsAndInternational GeographicReach = "us-and-international"
+	GeographicReachUsOnly             GeographicReach = "us-only"
+)
+
+type PendingLitigation string
+
+const (
+	PendingLitigationBankruptcyOrInsolvency               PendingLitigation = "bankruptcy-or-insolvency"
+	PendingLitigationConsumerProtectionOrClassAction      PendingLitigation = "consumer-protection-or-class-action"
+	PendingLitigationDataBreachOrPrivacy                  PendingLitigation = "data-breach-or-privacy"
+	PendingLitigationEmploymentOrWorkplaceDisputes        PendingLitigation = "employment-or-workplace-disputes"
+	PendingLitigationFraudOrFinancialCrime                PendingLitigation = "fraud-or-financial-crime"
+	PendingLitigationGovernmentEnforcementOrInvestigation PendingLitigation = "government-enforcement-or-investigation"
+	PendingLitigationIntellectualProperty                 PendingLitigation = "intellectual-property"
+	PendingLitigationNone                                 PendingLitigation = "none"
+	PendingLitigationOther                                PendingLitigation = "other"
+	PendingLitigationPersonalInjuryOrMedical              PendingLitigation = "personal-injury-or-medical"
+)
+
+type BusinessPresence string
+
+const (
+	BusinessPresenceCommercialOffice BusinessPresence = "commercial-office"
+	BusinessPresenceHomeBased        BusinessPresence = "home-based"
+	BusinessPresenceMixedPresence    BusinessPresence = "mixed-presence"
+	BusinessPresenceMobileBusiness   BusinessPresence = "mobile-business"
+	BusinessPresenceOnlineOnly       BusinessPresence = "online-only"
+	BusinessPresenceRetailStorefront BusinessPresence = "retail-storefront"
+)
+
+type VolumeShareByCustomerType struct {
+	Business *int `json:"business,omitempty"`
+	Consumer *int `json:"consumer,omitempty"`
+	P2P      *int `json:"p2p,omitempty"`
+}
+
+type EstimatedActivity struct {
+	AverageTransactionAmount *int64              `json:"averageTransactionAmount,omitempty"`
+	MaximumTransactionAmount *int64              `json:"maximumTransactionAmount,omitempty"`
+	MonthlyVolumeRange       *MonthlyVolumeRange `json:"monthlyVolumeRange,omitempty"`
+}
+
+// MonthlyVolumeRange includes the low value in each range and excludes the high value.
+type MonthlyVolumeRange string
+
+const (
+	MonthlyVolumeRangeUnder10K MonthlyVolumeRange = "under-10k"
+	MonthlyVolumeRange10K50K   MonthlyVolumeRange = "10k-50k"
+	MonthlyVolumeRange50K100K  MonthlyVolumeRange = "50k-100k"
+	MonthlyVolumeRange100K250K MonthlyVolumeRange = "100k-250k"
+	MonthlyVolumeRange250K500K MonthlyVolumeRange = "250k-500k"
+	MonthlyVolumeRange500K1M   MonthlyVolumeRange = "500k-1m"
+	MonthlyVolumeRange1M5M     MonthlyVolumeRange = "1m-5m"
+	MonthlyVolumeRangeOver5M   MonthlyVolumeRange = "over-5m"
+)
+
+type CollectFunds struct {
+	Ach          *CollectFundsAch          `json:"ach,omitempty"`
+	CardPayments *CollectFundsCardPayments `json:"cardPayments,omitempty"`
+}
+
+type CollectFundsAch struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type CollectFundsCardPayments struct {
+	CardAcceptanceMethods *CardAcceptanceMethods  `json:"cardAcceptanceMethods,omitempty"`
+	CurrentlyAcceptsCards *bool                   `json:"currentlyAcceptsCards,omitempty"`
+	EstimatedActivity     *EstimatedActivity      `json:"estimatedActivity,omitempty"`
+	Fulfillment           *CardPaymentFulfillment `json:"fulfillment,omitempty"`
+	RefundPolicy          *RefundPolicy           `json:"refundPolicy,omitempty"`
+}
+
+type CardAcceptanceMethods struct {
+	InPersonPercentage    *int `json:"inPersonPercentage,omitempty"`
+	MailOrPhonePercentage *int `json:"mailOrPhonePercentage,omitempty"`
+	OnlinePercentage      *int `json:"onlinePercentage,omitempty"`
+}
+
+type CardPaymentFulfillment struct {
+	Method    FulfillmentMethod    `json:"method"`
+	Timeframe FulfillmentTimeframe `json:"timeframe"`
+}
+
+type FulfillmentMethod string
+
+const (
+	FulfillmentMethodBillOrDebtPayment        FulfillmentMethod = "bill-or-debt-payment"
+	FulfillmentMethodDigitalContent           FulfillmentMethod = "digital-content"
+	FulfillmentMethodDonation                 FulfillmentMethod = "donation"
+	FulfillmentMethodInPersonService          FulfillmentMethod = "in-person-service"
+	FulfillmentMethodLocalPickupOrDelivery    FulfillmentMethod = "local-pickup-or-delivery"
+	FulfillmentMethodOther                    FulfillmentMethod = "other"
+	FulfillmentMethodRemoteService            FulfillmentMethod = "remote-service"
+	FulfillmentMethodShippedPhysicalGoods     FulfillmentMethod = "shipped-physical-goods"
+	FulfillmentMethodSubscriptionOrMembership FulfillmentMethod = "subscription-or-membership"
+)
+
+type FulfillmentTimeframe string
+
+const (
+	FulfillmentTimeframeImmediate         FulfillmentTimeframe = "immediate"
+	FulfillmentTimeframeOther             FulfillmentTimeframe = "other"
+	FulfillmentTimeframeOver30Days        FulfillmentTimeframe = "over-30-days"
+	FulfillmentTimeframePreOrder          FulfillmentTimeframe = "pre-order"
+	FulfillmentTimeframeRecurringSchedule FulfillmentTimeframe = "recurring-schedule"
+	FulfillmentTimeframeScheduledEvent    FulfillmentTimeframe = "scheduled-event"
+	FulfillmentTimeframeWithin30Days      FulfillmentTimeframe = "within-30-days"
+	FulfillmentTimeframeWithin7Days       FulfillmentTimeframe = "within-7-days"
+)
+
+type RefundPolicy string
+
+const (
+	RefundPolicyConditionalRefund        RefundPolicy = "conditional-refund"
+	RefundPolicyCustomPolicy             RefundPolicy = "custom-policy"
+	RefundPolicyEventBasedPolicy         RefundPolicy = "event-based-policy"
+	RefundPolicyFullRefundExtendedWindow RefundPolicy = "full-refund-extended-window"
+	RefundPolicyFullRefundWithin30Days   RefundPolicy = "full-refund-within-30-days"
+	RefundPolicyNoRefunds                RefundPolicy = "no-refunds"
+	RefundPolicyPartialRefund            RefundPolicy = "partial-refund"
+	RefundPolicyProratedRefund           RefundPolicy = "prorated-refund"
+	RefundPolicyStoreCreditOnly          RefundPolicy = "store-credit-only"
+)
+
+type MoneyTransfer struct {
+	PullFromCard *MoneyTransferPullFromCard `json:"pullFromCard,omitempty"`
+	PushToCard   *MoneyTransferPushToCard   `json:"pushToCard,omitempty"`
+}
+
+type MoneyTransferPullFromCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type MoneyTransferPushToCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFunds struct {
+	Ach         *SendFundsAch         `json:"ach,omitempty"`
+	PushToCard  *SendFundsPushToCard  `json:"pushToCard,omitempty"`
+	Rtp         *SendFundsRtp         `json:"rtp,omitempty"`
+	InstantBank *SendFundsInstantBank `json:"instantBank,omitempty"`
+	// Wire was added in v2026.07.
+	Wire *SendFundsWire `json:"wire,omitempty"`
+}
+
+type SendFundsAch struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsPushToCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsRtp struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsInstantBank struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+// SendFundsWire was added in v2026.07.
+type SendFundsWire struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SubmissionIntent string
+
+const (
+	SubmissionIntentWait   SubmissionIntent = "wait"
+	SubmissionIntentSubmit SubmissionIntent = "submit"
+)


### PR DESCRIPTION
Mirrors the moov-api `send-funds.wire` work (COR-4336) in the Go SDK.

The API gates the wire rail behind `@added(v2026q3)` in TypeSpec (`specification/underwriting/models.underwriting.tsp`: `SendFundsWire`, `SendFunds.wire`), so it's exposed through the versioned `mv2607` package. The `underwriting` service already serves it (`pkg/api/v2607`), so this is the SDK catching up.

Existing `mv2507` and pre-versioned underwriting surfaces are untouched.

## What's added

**`pkg/moov`** — version-agnostic generics, following the existing `*Generic` pattern:

- `GetUnderwritingGeneric[TUnderwriting]` and `UpsertUnderwritingGeneric[TRequest, TUnderwriting]`, each taking a `Version` and applying `MoovVersion(version)`. Upsert is `POST`, matching the versioned `saveUnderwriting` op (the pre-versioned `PUT upsertUnderwriting` stays on `Client.UpsertUnderwriting`).
- `CapabilityName_SendFundsWire` (`send-funds.wire`) — the backend requests this capability whenever `sendFunds.wire` is set, and capability names live unversioned in `moov`.

The existing `moov.UnderwritingClient[T, V]` generic struct is left in place; `mv2507` still uses it.

**`pkg/mv2607`** — the versioned surface:

- `UnderwritingClient` / `NewUnderwritingClient` embedding `*moov.Client`, wrapping both generics at `moov.Version2026_07`. This is the current versioning shape (`ProductClient`, `DepositViewClient`, `WalletClient`) rather than the package-level `var Underwriting = moov.UnderwritingClient[...]{Version: ...}` that `mv2507` uses.
- `UpsertUnderwriting` request and `Underwriting` response types, plus the full model set the package needs — each `mvXXXX` package owns its own types, no cross-version imports.
- `SendFundsWire` and `SendFunds.Wire`, mirroring `SendFundsInstantBank` exactly. `Wire` is `omitempty`, so pre-2026.07 payloads serialize byte-identically.

Two deliberate deviations from the `mv2507` copy, both in the new package only:

- The response type is `Underwriting`, matching the TypeSpec model name and the `Product`/`ProductRequest` naming already in `mv2607` (`mv2507` called it `UnderwritingResp`).
- The legacy v1 fields (`averageTransactionSize`, `fulfillment`, …) are `omitempty` pointers. TypeSpec marks them `@madeOptional(v2025q3)` and the service only populates them for accounts that submitted through the pre-versioned API, so `mv2507`'s value types can't distinguish absent from zero.

## Testing

`pkg/mv2607/underwriting_api_test.go` uses `httptest` to assert on the wire format: `POST`/`GET` against `/accounts/{accountID}/underwriting`, `X-Moov-Version: v2026.07.00` on both calls, `sendFunds.wire.estimatedActivity` present in the request body with all three fields, the wire rail decoding off the response, and `wire` omitted from `SendFunds` JSON when the rail is unset.

`pkg/mv2607/underwriting_integration_test.go` round-trips the rail against the real backend (upsert then get, asserting `SendFunds` comes back equal), reusing the existing `newIntegrationClient` skip-when-no-creds helper.

Verified locally:

- `go build ./...`, `go vet ./pkg/...`, `gofmt -l` — clean.
- `go test ./pkg/mv2607/...` — passes, including the integration test against the live backend, so the wire rail is confirmed end to end.
- `go test ./pkg/moov/ -run TestUpsertUnderwriting` — passes, `mv2507` unaffected.
- `make check` (moov-io/infra `lint-project.sh`) not run locally; CI covers it.
