### PR TITLE
Update statement_models.go

### DIFF
--- a/pkg/moov/statement_models.go
+++ b/pkg/moov/statement_models.go
@@ -43,6 +43,10 @@ type Summary struct {
 }
 
 type SummaryDetails struct {
+	// Deprecated: this field will be removed in a future release.
+	VolumeAmount *AmountDecimal `json:"volumeAmount,omitempty"`
+	// Deprecated: this field will be removed in a future release.
+	VolumeCount           *int64         `json:"volumeCount,omitempty"`
 	FeeAmount             *AmountDecimal `json:"feeAmount,omitempty"`
 	MerchantFeesCollected *AmountDecimal `json:"merchantFeesCollected,omitempty"`
 	PartnerFeesAssessed   *AmountDecimal `json:"partnerFeesAssessed,omitempty"`
@@ -90,20 +94,21 @@ type CountAndAmount struct {
 type InterchangeProgramFee struct {
 	Count          int64         `json:"count,omitempty"`
 	PerItemRate    AmountDecimal `json:"perItemRate,omitempty"`
-	PercentageRate string        `json:"percentageRate,omitempty"`
+	PercentageRate float64       `json:"percentageRate,omitempty"`
 	ProgramName    string        `json:"programName,omitempty"`
 	TransferVolume AmountDecimal `json:"transferVolume,omitempty"`
 	Total          AmountDecimal `json:"total,omitempty"`
 }
 
 type ACHFees struct {
-	Debits             CountAndAmount `json:"debits,omitempty"`
-	NoticeOfChange     CountAndAmount `json:"noticeOfChange,omitempty"`
-	Return             CountAndAmount `json:"return,omitempty"`
-	SameDayCredit      CountAndAmount `json:"sameDayCredit,omitempty"`
-	StandardCredit     CountAndAmount `json:"standardCredit,omitempty"`
-	UnauthorizedReturn CountAndAmount `json:"unauthorizedReturn,omitempty"`
-	Total              CountAndAmount `json:"total,omitempty"`
+	BankAccountVerification CountAndAmount `json:"bankAccountVerification,omitempty"`
+	Debits                  CountAndAmount `json:"debits,omitempty"`
+	NoticeOfChange          CountAndAmount `json:"noticeOfChange,omitempty"`
+	Return                  CountAndAmount `json:"return,omitempty"`
+	SameDayCredit           CountAndAmount `json:"sameDayCredit,omitempty"`
+	StandardCredit          CountAndAmount `json:"standardCredit,omitempty"`
+	UnauthorizedReturn      CountAndAmount `json:"unauthorizedReturn,omitempty"`
+	Total                   CountAndAmount `json:"total,omitempty"`
 }
 
 type InstantPaymentFees struct {
@@ -127,6 +132,7 @@ type PlatformFees struct {
 type AccountFees struct {
 	WalletFee                AmountDecimal  `json:"walletFee,omitempty"`
 	MerchantPCIFee           AmountDecimal  `json:"merchantPCIFee,omitempty"`
+	InvoicePaymentFee        AmountDecimal  `json:"invoicePaymentFee,omitempty"`
 	KYBFee                   *AmountDecimal `json:"kybFee,omitempty"`
 	KYCFee                   *AmountDecimal `json:"kycFee,omitempty"`
 	TransactionMonitoringFee *AmountDecimal `json:"transactionMonitoringFee,omitempty"`


### PR DESCRIPTION
builds were failing: https://github.com/moovfinancial/moov-go/actions/runs/31006267543/job/92306801034.

the `percentageRate` is not a string, it's a number. 