### PR TITLE
fix(statements)!: correct percentageRate type and add missing API fields

### DIFF
--- a/pkg/moov/statement_models.go
+++ b/pkg/moov/statement_models.go
@@ -1,6 +1,7 @@
 package moov
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -100,22 +101,20 @@ type InterchangeProgramFee struct {
 	Total          AmountDecimal  `json:"total,omitempty"`
 }
 
+// PercentageRate is an interchange percentage rate, held as the decimal literal exactly as the API sent it.
 type PercentageRate string
 
 func (r *PercentageRate) UnmarshalJSON(data []byte) error {
-	str := string(data)
-	if str == "null" {
-		return nil
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
 	}
-	*r = PercentageRate(str)
+	*r = PercentageRate(n)
 	return nil
 }
 
 func (r PercentageRate) MarshalJSON() ([]byte, error) {
-	if r == "" {
-		return []byte("null"), nil
-	}
-	return []byte(r), nil
+	return json.Marshal(json.Number(r))
 }
 
 type ACHFees struct {

--- a/pkg/moov/statement_models.go
+++ b/pkg/moov/statement_models.go
@@ -43,6 +43,10 @@ type Summary struct {
 }
 
 type SummaryDetails struct {
+	// Deprecated: this field will be removed in a future release.
+	VolumeAmount *AmountDecimal `json:"volumeAmount,omitempty"`
+	// Deprecated: this field will be removed in a future release.
+	VolumeCount           *int64         `json:"volumeCount,omitempty"`
 	FeeAmount             *AmountDecimal `json:"feeAmount,omitempty"`
 	MerchantFeesCollected *AmountDecimal `json:"merchantFeesCollected,omitempty"`
 	PartnerFeesAssessed   *AmountDecimal `json:"partnerFeesAssessed,omitempty"`
@@ -88,22 +92,41 @@ type CountAndAmount struct {
 }
 
 type InterchangeProgramFee struct {
-	Count          int64         `json:"count,omitempty"`
-	PerItemRate    AmountDecimal `json:"perItemRate,omitempty"`
-	PercentageRate string        `json:"percentageRate,omitempty"`
-	ProgramName    string        `json:"programName,omitempty"`
-	TransferVolume AmountDecimal `json:"transferVolume,omitempty"`
-	Total          AmountDecimal `json:"total,omitempty"`
+	Count          int64          `json:"count,omitempty"`
+	PerItemRate    AmountDecimal  `json:"perItemRate,omitempty"`
+	PercentageRate PercentageRate `json:"percentageRate,omitempty"`
+	ProgramName    string         `json:"programName,omitempty"`
+	TransferVolume AmountDecimal  `json:"transferVolume,omitempty"`
+	Total          AmountDecimal  `json:"total,omitempty"`
+}
+
+type PercentageRate string
+
+func (r *PercentageRate) UnmarshalJSON(data []byte) error {
+	str := string(data)
+	if str == "null" {
+		return nil
+	}
+	*r = PercentageRate(str)
+	return nil
+}
+
+func (r PercentageRate) MarshalJSON() ([]byte, error) {
+	if r == "" {
+		return []byte("null"), nil
+	}
+	return []byte(r), nil
 }
 
 type ACHFees struct {
-	Debits             CountAndAmount `json:"debits,omitempty"`
-	NoticeOfChange     CountAndAmount `json:"noticeOfChange,omitempty"`
-	Return             CountAndAmount `json:"return,omitempty"`
-	SameDayCredit      CountAndAmount `json:"sameDayCredit,omitempty"`
-	StandardCredit     CountAndAmount `json:"standardCredit,omitempty"`
-	UnauthorizedReturn CountAndAmount `json:"unauthorizedReturn,omitempty"`
-	Total              CountAndAmount `json:"total,omitempty"`
+	BankAccountVerification CountAndAmount `json:"bankAccountVerification,omitempty"`
+	Debits                  CountAndAmount `json:"debits,omitempty"`
+	NoticeOfChange          CountAndAmount `json:"noticeOfChange,omitempty"`
+	Return                  CountAndAmount `json:"return,omitempty"`
+	SameDayCredit           CountAndAmount `json:"sameDayCredit,omitempty"`
+	StandardCredit          CountAndAmount `json:"standardCredit,omitempty"`
+	UnauthorizedReturn      CountAndAmount `json:"unauthorizedReturn,omitempty"`
+	Total                   CountAndAmount `json:"total,omitempty"`
 }
 
 type InstantPaymentFees struct {
@@ -127,6 +150,7 @@ type PlatformFees struct {
 type AccountFees struct {
 	WalletFee                AmountDecimal  `json:"walletFee,omitempty"`
 	MerchantPCIFee           AmountDecimal  `json:"merchantPCIFee,omitempty"`
+	InvoicePaymentFee        AmountDecimal  `json:"invoicePaymentFee,omitempty"`
 	KYBFee                   *AmountDecimal `json:"kybFee,omitempty"`
 	KYCFee                   *AmountDecimal `json:"kycFee,omitempty"`
 	TransactionMonitoringFee *AmountDecimal `json:"transactionMonitoringFee,omitempty"`

--- a/pkg/moov/statement_models_test.go
+++ b/pkg/moov/statement_models_test.go
@@ -1,0 +1,164 @@
+package moov_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+func TestPercentageRate_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  moov.PercentageRate
+	}{
+		{"json number", `{"percentageRate":0.0195}`, "0.0195"},
+		{"trailing zeros preserved", `{"percentageRate":0.019500000}`, "0.019500000"},
+		{"nine decimal places", `{"percentageRate":1.123456789}`, "1.123456789"},
+		{"integer", `{"percentageRate":2}`, "2"},
+		{"negative", `{"percentageRate":-0.0195}`, "-0.0195"},
+		{"exponent", `{"percentageRate":1.95e-2}`, "1.95e-2"},
+		{"zero", `{"percentageRate":0}`, "0"},
+		{"field absent", `{"programName":"Visa CPS"}`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fee moov.InterchangeProgramFee
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &fee))
+			require.Equal(t, tt.want, fee.PercentageRate)
+		})
+	}
+}
+
+func TestPercentageRate_UnmarshalJSON_Errors(t *testing.T) {
+	t.Run("bool is a type error", func(t *testing.T) {
+		var fee moov.InterchangeProgramFee
+		err := json.Unmarshal([]byte(`{"percentageRate":true}`), &fee)
+		require.Error(t, err)
+
+		var typeErr *json.UnmarshalTypeError
+		require.ErrorAs(t, err, &typeErr)
+	})
+
+	t.Run("empty string is not a valid number", func(t *testing.T) {
+		var fee moov.InterchangeProgramFee
+		err := json.Unmarshal([]byte(`{"percentageRate":""}`), &fee)
+		require.ErrorContains(t, err, "invalid number literal")
+	})
+
+	t.Run("non-numeric string is not a valid number", func(t *testing.T) {
+		var fee moov.InterchangeProgramFee
+		err := json.Unmarshal([]byte(`{"percentageRate":"one percent"}`), &fee)
+		require.ErrorContains(t, err, "invalid number literal")
+	})
+}
+
+func TestPercentageRate_MarshalJSON(t *testing.T) {
+	t.Run("encodes as an unquoted number", func(t *testing.T) {
+		data, err := json.Marshal(moov.PercentageRate("0.0195"))
+		require.NoError(t, err)
+		require.Equal(t, `0.0195`, string(data))
+	})
+
+	t.Run("precision is not rounded through a float", func(t *testing.T) {
+		data, err := json.Marshal(moov.PercentageRate("1.123456789"))
+		require.NoError(t, err)
+		require.Equal(t, `1.123456789`, string(data))
+	})
+
+	t.Run("struct field is unquoted", func(t *testing.T) {
+		data, err := json.Marshal(moov.InterchangeProgramFee{PercentageRate: "0.0195"})
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"percentageRate":0.0195`)
+	})
+
+	t.Run("zero value is omitted", func(t *testing.T) {
+		data, err := json.Marshal(moov.InterchangeProgramFee{ProgramName: "Visa CPS"})
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "percentageRate")
+	})
+
+	t.Run("round trip is byte identical", func(t *testing.T) {
+		var fee moov.InterchangeProgramFee
+		require.NoError(t, json.Unmarshal([]byte(`{"percentageRate":0.019500000}`), &fee))
+
+		data, err := json.Marshal(fee.PercentageRate)
+		require.NoError(t, err)
+		require.Equal(t, `0.019500000`, string(data))
+	})
+}
+
+func TestPercentageRate_Float64(t *testing.T) {
+	var fee moov.InterchangeProgramFee
+	require.NoError(t, json.Unmarshal([]byte(`{"percentageRate":0.0195}`), &fee))
+
+	f, err := json.Number(fee.PercentageRate).Float64()
+	require.NoError(t, err)
+	require.InDelta(t, 0.0195, f, 1e-9)
+}
+
+// statementWithInterchangePrograms mirrors a statements response carrying a populated interchangePrograms array.
+// The array is omitted when empty, which is why the field's original string/number mismatch went unnoticed.
+const statementWithInterchangePrograms = `{
+  "statementID": "8e5b8c4f-6a1d-4f7e-9b3a-2c1d4e5f6a7b",
+  "statementName": "July 2026",
+  "billingPeriodStartDateTime": "2026-07-01T00:00:00Z",
+  "billingPeriodEndDateTime": "2026-08-01T00:00:00Z",
+  "summary": {
+    "cardAcquiring": {
+      "feeAmount": { "currency": "USD", "valueDecimal": "1204.567890000" },
+      "interchangeFees": {
+        "visa": { "currency": "USD", "valueDecimal": "900.120000000" },
+        "mastercard": { "currency": "USD", "valueDecimal": "304.447890000" },
+        "discover": { "currency": "USD", "valueDecimal": "0.000000000" },
+        "americanExpress": { "currency": "USD", "valueDecimal": "0.000000000" }
+      }
+    },
+    "total": { "currency": "USD", "valueDecimal": "1204.567890000" }
+  },
+  "cardAcquiringFees": {
+    "visa": {
+      "interchangePrograms": [
+        {
+          "count": 1250,
+          "perItemRate": { "currency": "USD", "valueDecimal": "0.100000000" },
+          "percentageRate": 0.0195,
+          "programName": "Visa CPS Retail",
+          "transferVolume": { "currency": "USD", "valueDecimal": "45000.000000000" },
+          "total": { "currency": "USD", "valueDecimal": "1002.500000000" }
+        },
+        {
+          "count": 40,
+          "perItemRate": { "currency": "USD", "valueDecimal": "0.050000000" },
+          "percentageRate": 1.123456789,
+          "programName": "Visa CPS Card Not Present",
+          "transferVolume": { "currency": "USD", "valueDecimal": "1200.000000000" },
+          "total": { "currency": "USD", "valueDecimal": "15.481481468" }
+        }
+      ],
+      "total": { "amount": { "currency": "USD", "valueDecimal": "1017.981481468" }, "count": 1290 }
+    }
+  }
+}`
+
+func TestStatement_InterchangePrograms(t *testing.T) {
+	var statement moov.Statement
+	err := strictDecoder(strings.NewReader(statementWithInterchangePrograms), "application/json", &statement)
+	require.NoError(t, err)
+
+	require.NotNil(t, statement.CardAcquiringFees)
+	programs := statement.CardAcquiringFees.Visa.InterchangePrograms
+	require.NotNil(t, programs)
+	require.Len(t, *programs, 2)
+
+	require.Equal(t, moov.PercentageRate("0.0195"), (*programs)[0].PercentageRate)
+	require.Equal(t, "Visa CPS Retail", (*programs)[0].ProgramName)
+
+	require.Equal(t, moov.PercentageRate("1.123456789"), (*programs)[1].PercentageRate)
+	require.Equal(t, int64(40), (*programs)[1].Count)
+}


### PR DESCRIPTION
## What

- Change `InterchangeProgramFee.PercentageRate` from `string` to a `PercentageRate` type that decodes a JSON number and holds its literal as text.
- Add `ACHFees.BankAccountVerification`.
- Add `AccountFees.InvoicePaymentFee`.
- Add `SummaryDetails.VolumeAmount` and `VolumeCount` (both deprecated in the spec).

## Why

Every statements test is failing with `json: cannot unmarshal number into Go struct field InterchangeProgramFee.cardAcquiringFees.visa.interchangePrograms.percentageRate of type string`.

`percentageRate` changed from a JSON string to a JSON number in billing-statements on 2025-12-11, when the statements response switched from a hand-rolled struct holding a `shopspring/decimal.Decimal` (which marshals quoted by default) to the generated `moovapi.BillingInterchangeProgramFee`, where the field is a `float32`. These models were hand-written one day earlier, against the old string output. The OpenAPI spec declares `percentageRate: {type: number, format: decimal}` in every published version back to v2024.01.00, so the number is correct and the old string was the spec violation. It stayed latent until now because `interchangePrograms` is omitted when empty, so the mismatch only surfaced once a statement in the test environment carried interchange program data.

The other three fields have been added to the statements API since these models were written. The test client decodes with `DisallowUnknownFields`, so each one is a hard failure the moment a statement includes it.

## Notes

- `PercentageRate` is a named string type rather than a float. The rate is stored as Spanner `NUMERIC` with scale 9, and a `float32` visibly corrupts values at that precision (`0.123456789` becomes `0.12345679`, `0.999999999` becomes `1`). Holding the decimal literal as text avoids the question entirely and matches how every other decimal crosses this API (`AmountDecimal.valueDecimal`, `FeeProperties.variableRate`, `summary.revenueShare`). Callers use `string(rate)` or `strconv.ParseFloat`.
- The receiver split is deliberate and mirrors `time.Time`: `UnmarshalJSON` takes a pointer because it must mutate, `MarshalJSON` takes a value so both `PercentageRate` and `*PercentageRate` satisfy `json.Marshaler`. Making both pointer receivers causes a struct field to re-marshal as a quoted string, since the field is not addressable and `encoding/json` then skips the method; making both value receivers makes `UnmarshalJSON` mutate a copy and silently decode to empty. Linters that flag mixed receivers are a false positive on marshaler pairs.
- Technically breaking: the field is retyped on an exported struct. In practice no working code can be reading it, since any response containing `interchangePrograms` failed to decode in full, so the field was never populated. Consumers with string-shaped code need only `string(rate)`.
- Verified by decoding a fully-populated `moovapi.Statement` — every optional field in the dev schema present — through the same strict `DisallowUnknownFields` decoder the test client uses: clean decode, `percentageRate` preserved exactly at 9 significant digits, re-marshals as an unquoted number.
- Separately, the service casts this rate to `float32` before serializing (`model_card_brand_program.go:28`), which corrupts values past roughly 7 significant digits before they ever reach a client. No client-side type can recover that; it needs a spec fix and is out of scope here.
- I could not run the live statements tests locally (no `secrets.env`), so CI is the real verification for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
