### PR TITLE
feat(issuing): add /details endpoint

### DIFF
--- a/pkg/moov/card_issuing_api.go
+++ b/pkg/moov/card_issuing_api.go
@@ -59,6 +59,22 @@ func (c Client) UpdateIssuedCard(ctx context.Context, accountID string, cardID s
 	return CompletedObjectOrError[IssuedCard](httpResp)
 }
 
+// GetIssuedCardDetails retrieves the specified issued card, including PCI details, for the given account
+// https://docs.moov.io/api/money-movement/issuing/get-details/
+//
+// To access this endpoint using an [access token](https://docs.moov.io/api/authentication/access-tokens/)
+// you'll need to specify the `/accounts/{accountID}/issued-cards.read-private` scope
+func (c Client) GetIssuedCardDetails(ctx context.Context, accountID string, cardID string) (*FullIssuedCard, error) {
+	httpResp, err := c.CallHttp(ctx,
+		Endpoint(http.MethodGet, pathIssuingCardDetails, accountID, cardID),
+		AcceptJson())
+	if err != nil {
+		return nil, err
+	}
+
+	return CompletedObjectOrError[FullIssuedCard](httpResp)
+}
+
 // ListIssuedCardAuthorizations retrieves all issued card authorizations for the given account
 // https://docs.moov.io/api/money-movement/issuing/list-authorizations/
 func (c Client) ListIssuedCardAuthorizations(ctx context.Context, accountID string, filters ...ListIssuedCardAuthorizationsFilter) ([]IssuedCardAuthorization, error) {

--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -294,6 +294,12 @@ func WithIssuedCardCount(count int) ListIssuedCardsFilter {
 	return Count(count)
 }
 
+type FullIssuedCard struct {
+	IssuedCard
+	PAN string `json:"pan"`
+	CVV string `json:"cvv"`
+}
+
 type CreateIssuedCard struct {
 	AuthorizedUserAccountID *string               `json:"authorizedUserAccountID,omitempty"`
 	Nickname                *string               `json:"nickname,omitempty"`

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -318,7 +318,7 @@ func Test_CardIssuing(t *testing.T) {
 	nickname := "testing"
 
 	// create issued card
-	// The card is issued to (and funded by the default wallet of) the MERCHANT_ID business
+	// The card is issued to (and funded by the card-issuing wallet of) the MERCHANT_ID business
 	// account. AuthorizedUserAccountID (an optional second cardholder) is omitted.
 	created, err := mc.CreateIssuedCard(BgCtx(), MERCHANT_ID, moov.CreateIssuedCard{
 		Nickname: &nickname,

--- a/pkg/moov/client.go
+++ b/pkg/moov/client.go
@@ -17,6 +17,8 @@ type Client struct {
 	decoder Decoder
 
 	bearerToken string
+	origin      string
+	referer     string
 
 	moovURLScheme string
 }
@@ -51,7 +53,8 @@ func NewClient(configurables ...ClientConfigurable) (*Client, error) {
 // given bearer token instead of Basic auth. Sets Credentials.Token and
 // revalidates. Intended for pass-through scenarios where a caller-supplied
 // access token should authenticate every call made by this client.
-func (c *Client) WithBearerToken(t string) *Client {
+// At least one of `Origin` or `Referer` header(s) must be included to not 401.
+func (c *Client) WithBearerToken(t, o, r string) *Client {
 	return &Client{
 		rateLimiter:   c.rateLimiter,
 		decoder:       c.decoder,
@@ -59,6 +62,8 @@ func (c *Client) WithBearerToken(t string) *Client {
 		Credentials:   c.Credentials,
 		HttpClient:    c.HttpClient,
 		bearerToken:   t,
+		origin:        o,
+		referer:       r,
 	}
 }
 

--- a/pkg/moov/client.go
+++ b/pkg/moov/client.go
@@ -57,6 +57,10 @@ func NewClient(configurables ...ClientConfigurable) (*Client, error) {
 // headers is sent, so pass WithOrigin and/or WithReferer options for those.
 // Any origin/referer already set on c carries over unless an option overrides it.
 func (c *Client) WithBearerToken(t string, opts ...BearerTokenOption) *Client {
+	if c == nil {
+		return nil
+	}
+
 	client := &Client{
 		rateLimiter:   c.rateLimiter,
 		decoder:       c.decoder,

--- a/pkg/moov/client.go
+++ b/pkg/moov/client.go
@@ -53,17 +53,42 @@ func NewClient(configurables ...ClientConfigurable) (*Client, error) {
 // given bearer token instead of Basic auth. Sets Credentials.Token and
 // revalidates. Intended for pass-through scenarios where a caller-supplied
 // access token should authenticate every call made by this client.
-// At least one of `Origin` or `Referer` header(s) must be included to not 401.
-func (c *Client) WithBearerToken(t, o, r string) *Client {
-	return &Client{
+// Bearer tokens may 401 unless at least one of the `Origin` or `Referer`
+// headers is sent, so pass WithOrigin and/or WithReferer options for those.
+// Any origin/referer already set on c carries over unless an option overrides it.
+func (c *Client) WithBearerToken(t string, opts ...BearerTokenOption) *Client {
+	client := &Client{
 		rateLimiter:   c.rateLimiter,
 		decoder:       c.decoder,
 		moovURLScheme: c.moovURLScheme,
 		Credentials:   c.Credentials,
 		HttpClient:    c.HttpClient,
 		bearerToken:   t,
-		origin:        o,
-		referer:       r,
+		origin:        c.origin,
+		referer:       c.referer,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// BearerTokenOption configures the headers sent alongside a bearer token.
+type BearerTokenOption func(c *Client)
+
+// WithOrigin sets the Origin header sent on every call made by the client.
+func WithOrigin(origin string) BearerTokenOption {
+	return func(c *Client) {
+		c.origin = origin
+	}
+}
+
+// WithReferer sets the Referer header sent on every call made by the client.
+func WithReferer(referer string) BearerTokenOption {
+	return func(c *Client) {
+		c.referer = referer
 	}
 }
 

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -45,17 +45,20 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("moov-go/%s", moovgo.Version()))
 
+	var bearerAuth bool
 	switch {
 	case call.token != nil:
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *call.token))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", *call.token))
+		bearerAuth = true
 	case c.bearerToken != "":
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+		bearerAuth = true
 	default:
 		req.SetBasicAuth(c.Credentials.PublicKey, c.Credentials.SecretKey)
 	}
 
 	// Bearer tokens 401 without at least one of these.
-	if strings.Contains(req.Header.Get("Authorization"), "Bearer") {
+	if bearerAuth {
 		if c.origin != "" && req.Header.Get("Origin") == "" {
 			req.Header.Set("Origin", c.origin)
 		}

--- a/pkg/moov/http.go
+++ b/pkg/moov/http.go
@@ -50,6 +50,12 @@ func (c *Client) CallHttp(ctx context.Context, endpoint EndpointArg, args ...cal
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *call.token))
 	case c.bearerToken != "":
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+		if c.origin != "" {
+			req.Header.Add("Origin", c.origin)
+		}
+		if c.referer != "" {
+			req.Header.Add("Referer", c.referer)
+		}
 	default:
 		req.SetBasicAuth(c.Credentials.PublicKey, c.Credentials.SecretKey)
 	}

--- a/pkg/moov/http_test.go
+++ b/pkg/moov/http_test.go
@@ -39,9 +39,10 @@ error from moov - status: bad_request http.request_id:  http.status_code: 400
 
 func TestCallHttp_AuthHeader(t *testing.T) {
 	type capture struct {
-		auth    string
-		origin  string
-		referer string
+		auth     string
+		allAuths []string
+		origin   string
+		referer  string
 	}
 
 	newClient := func(t *testing.T, cfg ...ClientConfigurable) (*Client, *capture) {
@@ -49,6 +50,7 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 		cap := &capture{}
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cap.auth = r.Header.Get("Authorization")
+			cap.allAuths = r.Header.Values("Authorization")
 			cap.origin = r.Header.Get("Origin")
 			cap.referer = r.Header.Get("Referer")
 			w.WriteHeader(http.StatusOK)
@@ -108,6 +110,26 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(cap.auth, "Basic "), "expected Basic auth, got %q", cap.auth)
+	})
+
+	t.Run("Basic auth does not send origin or referer", func(t *testing.T) {
+		c, cap := newClient(t)
+		c.origin, c.referer = "https://example.com", "https://example.com/checkout"
+		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(cap.auth, "Basic "), "expected Basic auth, got %q", cap.auth)
+		require.Empty(t, cap.origin)
+		require.Empty(t, cap.referer)
+	})
+
+	t.Run("only one Authorization header is sent", func(t *testing.T) {
+		c, cap := newClient(t)
+		c = c.WithBearerToken("abc")
+		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"),
+			Header("Authorization", "Bearer caller-supplied"))
+		require.NoError(t, err)
+		require.Len(t, cap.allAuths, 1)
+		require.Equal(t, "Bearer abc", cap.auth)
 	})
 }
 

--- a/pkg/moov/http_test.go
+++ b/pkg/moov/http_test.go
@@ -62,7 +62,7 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 
 	t.Run("Credentials.Token sends Bearer and omits Basic", func(t *testing.T) {
 		c, cap := newClient(t)
-		c = c.WithBearerToken("abc")
+		c = c.WithBearerToken("abc", "", "")
 		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
 		require.NoError(t, err)
 		require.Equal(t, "Bearer abc", cap.auth)
@@ -70,7 +70,7 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 
 	t.Run("WithToken option sets the bearer", func(t *testing.T) {
 		c, cap := newClient(t)
-		c = c.WithBearerToken("xyz")
+		c = c.WithBearerToken("xyz", "", "")
 		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
 		require.NoError(t, err)
 		require.Equal(t, "Bearer xyz", cap.auth)

--- a/pkg/moov/http_test.go
+++ b/pkg/moov/http_test.go
@@ -39,7 +39,9 @@ error from moov - status: bad_request http.request_id:  http.status_code: 400
 
 func TestCallHttp_AuthHeader(t *testing.T) {
 	type capture struct {
-		auth string
+		auth    string
+		origin  string
+		referer string
 	}
 
 	newClient := func(t *testing.T, cfg ...ClientConfigurable) (*Client, *capture) {
@@ -47,11 +49,15 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 		cap := &capture{}
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cap.auth = r.Header.Get("Authorization")
+			cap.origin = r.Header.Get("Origin")
+			cap.referer = r.Header.Get("Referer")
 			w.WriteHeader(http.StatusOK)
 		}))
 		t.Cleanup(srv.Close)
 
 		host := strings.TrimPrefix(srv.URL, "http://")
+		// Stub credentials up front so the tests don't depend on MOOV_* env vars.
+		cfg = append([]ClientConfigurable{WithCredentials(Credentials{PublicKey: "pk", SecretKey: "sk"})}, cfg...)
 		cfg = append(cfg, WithMoovURLScheme("http"))
 
 		c, err := NewClient(cfg...)
@@ -62,18 +68,39 @@ func TestCallHttp_AuthHeader(t *testing.T) {
 
 	t.Run("Credentials.Token sends Bearer and omits Basic", func(t *testing.T) {
 		c, cap := newClient(t)
-		c = c.WithBearerToken("abc", "", "")
+		c = c.WithBearerToken("abc")
 		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
 		require.NoError(t, err)
 		require.Equal(t, "Bearer abc", cap.auth)
+		require.Empty(t, cap.origin)
+		require.Empty(t, cap.referer)
 	})
 
 	t.Run("WithToken option sets the bearer", func(t *testing.T) {
 		c, cap := newClient(t)
-		c = c.WithBearerToken("xyz", "", "")
+		c = c.WithBearerToken("xyz")
 		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
 		require.NoError(t, err)
 		require.Equal(t, "Bearer xyz", cap.auth)
+	})
+
+	t.Run("WithOrigin and WithReferer set their headers", func(t *testing.T) {
+		c, cap := newClient(t)
+		c = c.WithBearerToken("abc", WithOrigin("https://example.com"), WithReferer("https://example.com/checkout"))
+		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
+		require.NoError(t, err)
+		require.Equal(t, "Bearer abc", cap.auth)
+		require.Equal(t, "https://example.com", cap.origin)
+		require.Equal(t, "https://example.com/checkout", cap.referer)
+	})
+
+	t.Run("origin and referer carry over to a re-tokened client", func(t *testing.T) {
+		c, cap := newClient(t)
+		c = c.WithBearerToken("abc", WithOrigin("https://example.com")).WithBearerToken("def")
+		_, err := c.CallHttp(context.Background(), Endpoint(http.MethodGet, "/ping"))
+		require.NoError(t, err)
+		require.Equal(t, "Bearer def", cap.auth)
+		require.Equal(t, "https://example.com", cap.origin)
 	})
 
 	t.Run("falls back to Basic auth when no token is set", func(t *testing.T) {

--- a/pkg/moov/paths.go
+++ b/pkg/moov/paths.go
@@ -137,6 +137,7 @@ const (
 
 	pathIssuedCards                = "/issuing/%s/cards"
 	pathIssuedCard                 = "/issuing/%s/cards/%s"
+	pathIssuingCardDetails         = "/issuing/%s/cards/%s/details"
 	pathIssuingAuthorizations      = "/issuing/%s/authorizations"
 	pathIssuingAuthorization       = "/issuing/%s/authorizations/%s"
 	pathIssuingAuthorizationEvents = "/issuing/%s/authorizations/%s/events"

--- a/pkg/moov/scopes.go
+++ b/pkg/moov/scopes.go
@@ -46,14 +46,14 @@ func (sl *scopeList) IssuedCardsRead(accountID string) ScopeBuilder {
 	return appendScope("/accounts/%s/issued-cards.read", accountID)
 }
 
-// Allows for the creation of a new issued card
+// Allows for creating and updating issued cards
 func (sl *scopeList) IssuedCardsWrite(accountID string) ScopeBuilder {
 	return appendScope("/accounts/%s/issued-cards.write", accountID)
 }
 
-// WARNING: Will return PCI data only allowed use case is by the customer directly to moov otherwise your business will require a PCI audit.
-func (sl *scopeList) IssuedCardsReadSecure(accountID string) ScopeBuilder {
-	return appendScope("/accounts/%s/issued-cards.read-secure", accountID)
+// WARNING: Will return PCI data only allowed use case is by the customer directly to moov otherwise your business will require a PCI audit
+func (sl *scopeList) IssuedCardsReadPrivate(accountID string) ScopeBuilder {
+	return appendScope("/accounts/%s/issued-cards.read-private", accountID)
 }
 
 // Give to the registered ApplePay merchants to allow them manage their ApplePay integration.


### PR DESCRIPTION
add [GET /issuing/{accountID}/cards/{issuedCardID}/details](https://docs.moov.io/api/money-movement/issuing/get-details) endpoint and relevant scope handling

also follow-up on https://github.com/moovfinancial/moov-go/pull/324 
* allow for optionally specifying `Origin` and / or `Referer` headers in an additive / non-breaking way when using `WithBearerToken` (these can alternatively still be set by using `Header` as a `callArg` param for `CallHttp` when needed)
* use `Header.Set` instead of `Header.Add` for `Authorization: Bearer` so only 1 auth header will be present, matching `SetBasicAuth`

--

FYI:

this was validated through testing, truncated ex.
```go
// get details for issued card
token, err := mc.AccessToken(BgCtx(), moov.Scopes.IssuedCardsReadPrivate(MERCHANT_ID))
NoResponseError(t, err)

cardDetails, err := mc.WithBearerToken(token.AccessToken, moov.WithOrigin(fmt.Sprintf("https://%s", mc.Credentials.Host))).GetIssuedCardDetails(BgCtx(), MERCHANT_ID, created.IssuedCardID)
NoResponseError(t, err)
require.NotNil(t, cardDetails)
```

but relevant UTs are intentionally not being committed to avoid PCI scope data