### PR TITLE
feat(underwriting): add card-issuing to dynamic underwriting

### DIFF
--- a/pkg/mv2610/underwriting_api.go
+++ b/pkg/mv2610/underwriting_api.go
@@ -1,0 +1,28 @@
+package mv2610
+
+import (
+	"context"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+)
+
+type UnderwritingClient struct {
+	*moov.Client
+}
+
+func NewUnderwritingClient(client *moov.Client) UnderwritingClient {
+	return UnderwritingClient{Client: client}
+}
+
+// GetUnderwriting returns the underwriting information for the given account.
+// https://docs.moov.io/guides/accounts/requirements/underwriting/
+func (u UnderwritingClient) GetUnderwriting(ctx context.Context, accountID string) (*Underwriting, error) {
+	return moov.GetUnderwritingGeneric[Underwriting](ctx, u.Client, moov.Version2026_10, accountID)
+}
+
+// UpsertUnderwriting adds or updates underwriting information for the given account.
+// Returns the underwriting information for the account.
+// https://docs.moov.io/guides/accounts/requirements/underwriting/
+func (u UnderwritingClient) UpsertUnderwriting(ctx context.Context, accountID string, underwriting UpsertUnderwriting) (*Underwriting, error) {
+	return moov.UpsertUnderwritingGeneric[UpsertUnderwriting, Underwriting](ctx, u.Client, moov.Version2026_10, accountID, underwriting)
+}

--- a/pkg/mv2610/underwriting_api_test.go
+++ b/pkg/mv2610/underwriting_api_test.go
@@ -1,0 +1,170 @@
+package mv2610_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2610"
+)
+
+// newUnderwritingTestClient points a client at srv so tests can assert on the raw request.
+func newUnderwritingTestClient(t *testing.T, srv *httptest.Server) mv2610.UnderwritingClient {
+	t.Helper()
+
+	client, err := moov.NewClient(
+		moov.WithCredentials(moov.Credentials{PublicKey: "pk", SecretKey: "sk"}),
+		moov.WithMoovURLScheme("http"),
+	)
+	require.NoError(t, err)
+	client.Credentials.Host = strings.TrimPrefix(srv.URL, "http://")
+
+	return mv2610.NewUnderwritingClient(client)
+}
+
+const underwritingWithCardIssuingJSON = `{
+	"geographicReach": "us-only",
+	"sendFunds": {
+		"wire": {
+			"estimatedActivity": {
+				"monthlyVolumeRange": "1m-5m"
+			}
+		}
+	},
+	"cardIssuing": {
+		"estimatedActivity": {
+			"averageTransactionAmount": 5000,
+			"maximumTransactionAmount": 50000,
+			"monthlyVolumeRange": "50k-100k"
+		}
+	}
+}`
+
+func TestUpsertUnderwriting(t *testing.T) {
+	var (
+		method    string
+		path      string
+		version   string
+		body      map[string]any
+		decodeErr error
+	)
+
+	// The handler runs on its own goroutine, so it records what it saw rather than
+	// asserting: require.* calls t.FailNow, which is only valid on the test goroutine.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+		decodeErr = json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(underwritingWithCardIssuingJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	actual, err := underwriting.UpsertUnderwriting(context.Background(), "account-123", mv2610.UpsertUnderwriting{
+		GeographicReach: moov.PtrOf(mv2610.GeographicReachUsOnly),
+		CardIssuing: &mv2610.CardIssuing{
+			EstimatedActivity: &mv2610.EstimatedActivity{
+				AverageTransactionAmount: moov.PtrOf(int64(5_000)),
+				MaximumTransactionAmount: moov.PtrOf(int64(50_000)),
+				MonthlyVolumeRange:       moov.PtrOf(mv2610.MonthlyVolumeRange50K100K),
+			},
+		},
+		SubmissionIntent: moov.PtrOf(mv2610.SubmissionIntentSubmit),
+	})
+	require.NoError(t, err)
+	require.NoError(t, decodeErr)
+
+	require.Equal(t, http.MethodPost, method)
+	require.Equal(t, "/accounts/account-123/underwriting", path)
+	require.Equal(t, moov.Version2026_10.String(), version)
+
+	cardIssuing, ok := body["cardIssuing"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"averageTransactionAmount": float64(5_000),
+		"maximumTransactionAmount": float64(50_000),
+		"monthlyVolumeRange":       "50k-100k",
+	}, cardIssuing["estimatedActivity"])
+
+	require.NotNil(t, actual)
+	require.NotNil(t, actual.CardIssuing)
+	require.NotNil(t, actual.CardIssuing.EstimatedActivity)
+	require.Equal(t, moov.PtrOf(mv2610.MonthlyVolumeRange50K100K), actual.CardIssuing.EstimatedActivity.MonthlyVolumeRange)
+	require.Equal(t, moov.PtrOf(int64(5_000)), actual.CardIssuing.EstimatedActivity.AverageTransactionAmount)
+	require.Equal(t, moov.PtrOf(int64(50_000)), actual.CardIssuing.EstimatedActivity.MaximumTransactionAmount)
+}
+
+func TestGetUnderwriting(t *testing.T) {
+	var (
+		method  string
+		path    string
+		version string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		version = r.Header.Get(moov.VersionHeader)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(underwritingWithCardIssuingJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	actual, err := underwriting.GetUnderwriting(context.Background(), "account-123")
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, method)
+	require.Equal(t, "/accounts/account-123/underwriting", path)
+	require.Equal(t, moov.Version2026_10.String(), version)
+
+	require.NotNil(t, actual)
+	require.Equal(t, moov.PtrOf(mv2610.GeographicReachUsOnly), actual.GeographicReach)
+	require.NotNil(t, actual.SendFunds)
+	require.NotNil(t, actual.SendFunds.Wire)
+	require.NotNil(t, actual.CardIssuing)
+	require.Equal(t, moov.PtrOf(mv2610.MonthlyVolumeRange50K100K), actual.CardIssuing.EstimatedActivity.MonthlyVolumeRange)
+}
+
+// An empty accountID would produce /accounts//underwriting, so both calls must fail
+// before reaching the network.
+func TestUnderwritingRequiresAccountID(t *testing.T) {
+	called := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	t.Cleanup(srv.Close)
+
+	underwriting := newUnderwritingTestClient(t, srv)
+
+	_, err := underwriting.GetUnderwriting(context.Background(), "")
+	require.EqualError(t, err, "accountID is required")
+
+	_, err = underwriting.UpsertUnderwriting(context.Background(), "", mv2610.UpsertUnderwriting{})
+	require.EqualError(t, err, "accountID is required")
+
+	require.False(t, called, "no request should reach the server")
+}
+
+// UpsertUnderwriting must not emit a cardIssuing key when it isn't set, so pre-v2026.10
+// shapes round-trip unchanged.
+func TestUpsertOmitsCardIssuingWhenUnset(t *testing.T) {
+	b, err := json.Marshal(mv2610.UpsertUnderwriting{
+		SendFunds: &mv2610.SendFunds{Wire: &mv2610.SendFundsWire{}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"cardIssuing"`)
+}

--- a/pkg/mv2610/underwriting_integration_test.go
+++ b/pkg/mv2610/underwriting_integration_test.go
@@ -1,0 +1,122 @@
+package mv2610_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moovfinancial/moov-go/pkg/moov"
+	"github.com/moovfinancial/moov-go/pkg/mv2610"
+)
+
+// newIntegrationClient builds a client against the real Moov backend using
+// credentials from the environment (optionally loaded from secrets.env at the repo
+// root). The test is skipped when credentials are unavailable so it stays CI-safe.
+func newIntegrationClient(t *testing.T) *moov.Client {
+	t.Helper()
+
+	secretsPath := filepath.Join("..", "..", "secrets.env")
+	if secrets, err := godotenv.Read(secretsPath); err == nil {
+		for k, v := range secrets {
+			t.Setenv(k, v)
+		}
+	}
+
+	if os.Getenv("MOOV_PUBLIC_KEY") == "" || os.Getenv("MOOV_SECRET_KEY") == "" {
+		t.Skip("MOOV_PUBLIC_KEY/MOOV_SECRET_KEY not set; skipping integration test")
+	}
+
+	client, err := moov.NewClient()
+	require.NoError(t, err)
+
+	if err := client.Ping(context.Background()); err != nil {
+		t.Skipf("unable to reach Moov backend, skipping integration test: %v", err)
+	}
+
+	return client
+}
+
+func TestUpsertUnderwriting_Integration(t *testing.T) {
+	client := newIntegrationClient(t)
+	ctx := context.Background()
+
+	created, started, err := client.CreateAccount(ctx, moov.CreateAccount{
+		Type: moov.AccountType_Business,
+		Profile: moov.CreateProfile{
+			Business: &moov.CreateBusinessProfile{
+				Name:        "moov-go underwriting SDK test",
+				Type:        moov.BusinessType_Llc,
+				Description: "moov-go SDK underwriting integration test",
+				IndustryCodes: &moov.IndustryCodes{
+					Mcc:   "6012",
+					Naics: "522110",
+					Sic:   "6021",
+				},
+				Industry: "electronics-appliances",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	account := created
+	if account == nil {
+		account = started
+	}
+	require.NotNil(t, account)
+
+	t.Cleanup(func() {
+		_ = client.DisconnectAccount(context.Background(), account.AccountID)
+	})
+
+	underwriting := mv2610.NewUnderwritingClient(client)
+
+	upsert := mv2610.UpsertUnderwriting{
+		GeographicReach:   moov.PtrOf(mv2610.GeographicReachUsOnly),
+		BusinessPresence:  moov.PtrOf(mv2610.BusinessPresenceHomeBased),
+		PendingLitigation: moov.PtrOf(mv2610.PendingLitigationNone),
+		VolumeShareByCustomerType: &mv2610.VolumeShareByCustomerType{
+			Business: moov.PtrOf(70),
+			Consumer: moov.PtrOf(30),
+			P2P:      moov.PtrOf(0),
+		},
+		SendFunds: &mv2610.SendFunds{
+			Ach: &mv2610.SendFundsAch{
+				EstimatedActivity: &mv2610.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2610.MonthlyVolumeRangeUnder10K)},
+			},
+			Wire: &mv2610.SendFundsWire{
+				EstimatedActivity: &mv2610.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2610.MonthlyVolumeRange1M5M)},
+			},
+		},
+		CardIssuing: &mv2610.CardIssuing{
+			EstimatedActivity: &mv2610.EstimatedActivity{MonthlyVolumeRange: moov.PtrOf(mv2610.MonthlyVolumeRange50K100K)},
+		},
+		SubmissionIntent: moov.PtrOf(mv2610.SubmissionIntentWait),
+	}
+
+	t.Run("upsert", func(t *testing.T) {
+		actual, err := underwriting.UpsertUnderwriting(ctx, account.AccountID, upsert)
+		require.NoError(t, err)
+
+		require.NotNil(t, actual)
+		require.Equal(t, upsert.GeographicReach, actual.GeographicReach)
+		require.Equal(t, upsert.BusinessPresence, actual.BusinessPresence)
+		require.Equal(t, upsert.PendingLitigation, actual.PendingLitigation)
+		require.Equal(t, upsert.VolumeShareByCustomerType, actual.VolumeShareByCustomerType)
+		require.Equal(t, upsert.SendFunds, actual.SendFunds)
+		require.Equal(t, upsert.CardIssuing, actual.CardIssuing)
+	})
+
+	t.Run("get", func(t *testing.T) {
+		actual, err := underwriting.GetUnderwriting(ctx, account.AccountID)
+		require.NoError(t, err)
+
+		require.NotNil(t, actual)
+		require.Equal(t, upsert.GeographicReach, actual.GeographicReach)
+		require.Equal(t, upsert.SendFunds, actual.SendFunds)
+		require.Equal(t, upsert.CardIssuing, actual.CardIssuing)
+	})
+}

--- a/pkg/mv2610/underwriting_models.go
+++ b/pkg/mv2610/underwriting_models.go
@@ -1,0 +1,225 @@
+package mv2610
+
+import "github.com/moovfinancial/moov-go/pkg/moov"
+
+// UpsertUnderwriting is the v2026.10 underwriting request body.
+type UpsertUnderwriting struct {
+	GeographicReach           *GeographicReach           `json:"geographicReach,omitempty"`
+	BusinessPresence          *BusinessPresence          `json:"businessPresence,omitempty"`
+	PendingLitigation         *PendingLitigation         `json:"pendingLitigation,omitempty"`
+	VolumeShareByCustomerType *VolumeShareByCustomerType `json:"volumeShareByCustomerType,omitempty"`
+	CollectFunds              *CollectFunds              `json:"collectFunds,omitempty"`
+	MoneyTransfer             *MoneyTransfer             `json:"moneyTransfer,omitempty"`
+	SendFunds                 *SendFunds                 `json:"sendFunds,omitempty"`
+	// CardIssuing was added in v2026.10.
+	CardIssuing      *CardIssuing      `json:"cardIssuing,omitempty"`
+	SubmissionIntent *SubmissionIntent `json:"submissionIntent,omitempty"`
+}
+
+// Underwriting is the v2026.10 underwriting response. The legacy fields are only
+// returned for accounts that submitted underwriting through the pre-versioned API, so
+// they're optional.
+type Underwriting struct {
+	AverageTransactionSize          *int64                       `json:"averageTransactionSize,omitempty"`
+	MaxTransactionSize              *int64                       `json:"maxTransactionSize,omitempty"`
+	AverageMonthlyTransactionVolume *int64                       `json:"averageMonthlyTransactionVolume,omitempty"`
+	VolumeByCustomerType            *moov.VolumeByCustomerType   `json:"volumeByCustomerType,omitempty"`
+	CardVolumeDistribution          *moov.CardVolumeDistribution `json:"cardVolumeDistribution,omitempty"`
+	Fulfillment                     *moov.Fulfillment            `json:"fulfillment,omitempty"`
+
+	GeographicReach           *GeographicReach           `json:"geographicReach,omitempty"`
+	BusinessPresence          *BusinessPresence          `json:"businessPresence,omitempty"`
+	PendingLitigation         *PendingLitigation         `json:"pendingLitigation,omitempty"`
+	VolumeShareByCustomerType *VolumeShareByCustomerType `json:"volumeShareByCustomerType,omitempty"`
+	CollectFunds              *CollectFunds              `json:"collectFunds,omitempty"`
+	MoneyTransfer             *MoneyTransfer             `json:"moneyTransfer,omitempty"`
+	SendFunds                 *SendFunds                 `json:"sendFunds,omitempty"`
+	// CardIssuing was added in v2026.10.
+	CardIssuing *CardIssuing `json:"cardIssuing,omitempty"`
+}
+
+type GeographicReach string
+
+const (
+	GeographicReachInternationalOnly  GeographicReach = "international-only"
+	GeographicReachUsAndInternational GeographicReach = "us-and-international"
+	GeographicReachUsOnly             GeographicReach = "us-only"
+)
+
+type PendingLitigation string
+
+const (
+	PendingLitigationBankruptcyOrInsolvency               PendingLitigation = "bankruptcy-or-insolvency"
+	PendingLitigationConsumerProtectionOrClassAction      PendingLitigation = "consumer-protection-or-class-action"
+	PendingLitigationDataBreachOrPrivacy                  PendingLitigation = "data-breach-or-privacy"
+	PendingLitigationEmploymentOrWorkplaceDisputes        PendingLitigation = "employment-or-workplace-disputes"
+	PendingLitigationFraudOrFinancialCrime                PendingLitigation = "fraud-or-financial-crime"
+	PendingLitigationGovernmentEnforcementOrInvestigation PendingLitigation = "government-enforcement-or-investigation"
+	PendingLitigationIntellectualProperty                 PendingLitigation = "intellectual-property"
+	PendingLitigationNone                                 PendingLitigation = "none"
+	PendingLitigationOther                                PendingLitigation = "other"
+	PendingLitigationPersonalInjuryOrMedical              PendingLitigation = "personal-injury-or-medical"
+)
+
+type BusinessPresence string
+
+const (
+	BusinessPresenceCommercialOffice BusinessPresence = "commercial-office"
+	BusinessPresenceHomeBased        BusinessPresence = "home-based"
+	BusinessPresenceMixedPresence    BusinessPresence = "mixed-presence"
+	BusinessPresenceMobileBusiness   BusinessPresence = "mobile-business"
+	BusinessPresenceOnlineOnly       BusinessPresence = "online-only"
+	BusinessPresenceRetailStorefront BusinessPresence = "retail-storefront"
+)
+
+type VolumeShareByCustomerType struct {
+	Business *int `json:"business,omitempty"`
+	Consumer *int `json:"consumer,omitempty"`
+	P2P      *int `json:"p2p,omitempty"`
+}
+
+type EstimatedActivity struct {
+	AverageTransactionAmount *int64              `json:"averageTransactionAmount,omitempty"`
+	MaximumTransactionAmount *int64              `json:"maximumTransactionAmount,omitempty"`
+	MonthlyVolumeRange       *MonthlyVolumeRange `json:"monthlyVolumeRange,omitempty"`
+}
+
+// MonthlyVolumeRange includes the low value in each range and excludes the high value.
+type MonthlyVolumeRange string
+
+const (
+	MonthlyVolumeRangeUnder10K MonthlyVolumeRange = "under-10k"
+	MonthlyVolumeRange10K50K   MonthlyVolumeRange = "10k-50k"
+	MonthlyVolumeRange50K100K  MonthlyVolumeRange = "50k-100k"
+	MonthlyVolumeRange100K250K MonthlyVolumeRange = "100k-250k"
+	MonthlyVolumeRange250K500K MonthlyVolumeRange = "250k-500k"
+	MonthlyVolumeRange500K1M   MonthlyVolumeRange = "500k-1m"
+	MonthlyVolumeRange1M5M     MonthlyVolumeRange = "1m-5m"
+	MonthlyVolumeRangeOver5M   MonthlyVolumeRange = "over-5m"
+)
+
+type CollectFunds struct {
+	Ach          *CollectFundsAch          `json:"ach,omitempty"`
+	CardPayments *CollectFundsCardPayments `json:"cardPayments,omitempty"`
+}
+
+type CollectFundsAch struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type CollectFundsCardPayments struct {
+	CardAcceptanceMethods *CardAcceptanceMethods  `json:"cardAcceptanceMethods,omitempty"`
+	CurrentlyAcceptsCards *bool                   `json:"currentlyAcceptsCards,omitempty"`
+	EstimatedActivity     *EstimatedActivity      `json:"estimatedActivity,omitempty"`
+	Fulfillment           *CardPaymentFulfillment `json:"fulfillment,omitempty"`
+	RefundPolicy          *RefundPolicy           `json:"refundPolicy,omitempty"`
+}
+
+type CardAcceptanceMethods struct {
+	InPersonPercentage    *int `json:"inPersonPercentage,omitempty"`
+	MailOrPhonePercentage *int `json:"mailOrPhonePercentage,omitempty"`
+	OnlinePercentage      *int `json:"onlinePercentage,omitempty"`
+}
+
+type CardPaymentFulfillment struct {
+	Method    FulfillmentMethod    `json:"method"`
+	Timeframe FulfillmentTimeframe `json:"timeframe"`
+}
+
+type FulfillmentMethod string
+
+const (
+	FulfillmentMethodBillOrDebtPayment        FulfillmentMethod = "bill-or-debt-payment"
+	FulfillmentMethodDigitalContent           FulfillmentMethod = "digital-content"
+	FulfillmentMethodDonation                 FulfillmentMethod = "donation"
+	FulfillmentMethodInPersonService          FulfillmentMethod = "in-person-service"
+	FulfillmentMethodLocalPickupOrDelivery    FulfillmentMethod = "local-pickup-or-delivery"
+	FulfillmentMethodOther                    FulfillmentMethod = "other"
+	FulfillmentMethodRemoteService            FulfillmentMethod = "remote-service"
+	FulfillmentMethodShippedPhysicalGoods     FulfillmentMethod = "shipped-physical-goods"
+	FulfillmentMethodSubscriptionOrMembership FulfillmentMethod = "subscription-or-membership"
+)
+
+type FulfillmentTimeframe string
+
+const (
+	FulfillmentTimeframeImmediate         FulfillmentTimeframe = "immediate"
+	FulfillmentTimeframeOther             FulfillmentTimeframe = "other"
+	FulfillmentTimeframeOver30Days        FulfillmentTimeframe = "over-30-days"
+	FulfillmentTimeframePreOrder          FulfillmentTimeframe = "pre-order"
+	FulfillmentTimeframeRecurringSchedule FulfillmentTimeframe = "recurring-schedule"
+	FulfillmentTimeframeScheduledEvent    FulfillmentTimeframe = "scheduled-event"
+	FulfillmentTimeframeWithin30Days      FulfillmentTimeframe = "within-30-days"
+	FulfillmentTimeframeWithin7Days       FulfillmentTimeframe = "within-7-days"
+)
+
+type RefundPolicy string
+
+const (
+	RefundPolicyConditionalRefund        RefundPolicy = "conditional-refund"
+	RefundPolicyCustomPolicy             RefundPolicy = "custom-policy"
+	RefundPolicyEventBasedPolicy         RefundPolicy = "event-based-policy"
+	RefundPolicyFullRefundExtendedWindow RefundPolicy = "full-refund-extended-window"
+	RefundPolicyFullRefundWithin30Days   RefundPolicy = "full-refund-within-30-days"
+	RefundPolicyNoRefunds                RefundPolicy = "no-refunds"
+	RefundPolicyPartialRefund            RefundPolicy = "partial-refund"
+	RefundPolicyProratedRefund           RefundPolicy = "prorated-refund"
+	RefundPolicyStoreCreditOnly          RefundPolicy = "store-credit-only"
+)
+
+type MoneyTransfer struct {
+	PullFromCard *MoneyTransferPullFromCard `json:"pullFromCard,omitempty"`
+	PushToCard   *MoneyTransferPushToCard   `json:"pushToCard,omitempty"`
+}
+
+type MoneyTransferPullFromCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type MoneyTransferPushToCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFunds struct {
+	Ach         *SendFundsAch         `json:"ach,omitempty"`
+	PushToCard  *SendFundsPushToCard  `json:"pushToCard,omitempty"`
+	Rtp         *SendFundsRtp         `json:"rtp,omitempty"`
+	InstantBank *SendFundsInstantBank `json:"instantBank,omitempty"`
+	Wire        *SendFundsWire        `json:"wire,omitempty"`
+}
+
+type SendFundsAch struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsPushToCard struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsRtp struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsInstantBank struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SendFundsWire struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+// CardIssuing is the underwriting data for the card-issuing capability, added in
+// v2026.10. Card issuing has no granular rails, so it hangs directly off the
+// underwriting root rather than acting as a container like SendFunds. Issued cards are
+// funded from the account's wallet before they can be spent, so estimated activity is
+// the only data collected.
+type CardIssuing struct {
+	EstimatedActivity *EstimatedActivity `json:"estimatedActivity,omitempty"`
+}
+
+type SubmissionIntent string
+
+const (
+	SubmissionIntentWait   SubmissionIntent = "wait"
+	SubmissionIntentSubmit SubmissionIntent = "submit"
+)


### PR DESCRIPTION
[COR-4364](https://linear.app/moov/issue/COR-4364/underwriting-add-card-issuing-to-dynamic-underwriting)

Mirrors moov-api `8aba86d6`, which added the card-issuing underwriting data at `v2026q4` (v2026.10), matching what the underwriting service already serves (moovfinancial/underwriting#223).

## Why a new `mv2610` package

`CardIssuing` is `@added(v2026q4)`, so it can't go in `pkg/mv2607` — that client pins `moov.Version2026_07`, and the API doesn't return `cardIssuing` at that version. This follows `7893cac`, which created `mv2607` for the `send-funds.wire` rail.

Card issuing has no granular rails, so `CardIssuing` hangs off the underwriting root rather than acting as a container like `SendFunds`. Issued cards are funded from the account's wallet before they can be spent, so estimated activity is the only data collected.

## Scope

Everything is additive and confined to the new package:

- `pkg/mv2610/underwriting_models.go` — the v2026.07 model set plus `CardIssuing` on `UpsertUnderwriting` and `Underwriting`
- `pkg/mv2610/underwriting_api.go` — `UnderwritingClient` over the existing `moov.GetUnderwritingGeneric` / `UpsertUnderwritingGeneric`, pinned to `moov.Version2026_10`

Nothing outside `pkg/mv2610` changed. `moov.Version2026_10` and `CapabilityName_CardIssuing` already existed, and moov-go's `RequirementId` enum carries no `underwriting.*` IDs, so the new `underwriting.cardIssuing.estimatedActivity.monthlyVolumeRange` requirement ID has no counterpart to add here.

The client surface matches the other versioned packages exactly — same `Client struct { *moov.Client }` embedding and `NewXClient(*moov.Client)` constructor as `NewSweepClient`, `NewWalletClient`, `NewProductClient`, `NewTransferClient`, and `NewDepositViewClient`, with the version pinned inside the method so callers never type a version constant.

## Self-contained models, deliberately

The models are a copy rather than aliases into a shared tree in `pkg/moov`. Aliasing would let a customer's `mv2607` values carry over to `mv2610`, but it also means a future quarterly edit to a shared type silently exposes a field to versions that reject it. The copy costs a retype on upgrade — a compile error, never a runtime surprise — and keeps each package provably equal to what its version accepts. This is the same reason underwriting already diverged from the transfers/products pattern at `mv2507` and `mv2607`.

## Testing

- `pkg/mv2610/underwriting_api_test.go` — httptest round trip asserting the `X-Moov-Version` header is `v2026.10.00`, the serialized `cardIssuing.estimatedActivity` request body, response decode, the empty-accountID guard, and that `cardIssuing` is omitted when unset
- `pkg/mv2610/underwriting_integration_test.go` — same skip-without-credentials shape as `mv2607`; run against the live backend, where `cardIssuing` round-tripped through both upsert and get

`SKIP_TESTS=yes make check` is clean: builds, govulncheck finds no vulnerabilities, golangci-lint reports 0 issues.

## Follow-up worth a ticket

Nothing asserts that `mv2607` *omits* v2026.10-only fields or that `mv2507` omits `wire`. Version isolation currently rests on the copy discipline alone. This PR adds that assertion in the `mv2610` direction (`TestUpsertOmitsCardIssuingWhenUnset`); the older packages have no equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)