### PR TITLE
feat(issuing): ISSU-1325: support frozen card state

### DIFF
--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -43,6 +43,9 @@ const (
 	// operational and can approve incoming authorizations
 	IssuedCardState_Active IssuedCardState = "active"
 
+	// temporarily deactivated and cannot approve incoming authorizations, but can be reactivated
+	IssuedCardState_Frozen IssuedCardState = "frozen"
+
 	// permanently deactivated, either by request or because it expired, and cannot approve incoming authorizations
 	IssuedCardState_Closed IssuedCardState = "closed"
 )
@@ -320,6 +323,13 @@ type UpdateIssuedCard struct {
 type UpdateIssuedCardState string
 
 const (
+	// reactivate a frozen card so it can approve incoming authorizations
+	UpdateIssuedCardState_Active UpdateIssuedCardState = "active"
+
+	// temporarily deactivate a card so it cannot approve incoming authorizations, but can be reactivated
+	UpdateIssuedCardState_Frozen UpdateIssuedCardState = "frozen"
+
+	// permanently deactivate a card so it cannot approve incoming authorizations
 	UpdateIssuedCardState_Closed UpdateIssuedCardState = "closed"
 )
 


### PR DESCRIPTION
## What

Adds the new `frozen` card state to the card issuing models:

- **`IssuedCardState`** (GET) — adds `IssuedCardState_Frozen = "frozen"`.
- **`UpdateIssuedCardState`** (PATCH) — adds `UpdateIssuedCardState_Frozen = "frozen"` and `UpdateIssuedCardState_Active = "active"` (a frozen card can be reactivated).

## Why

Support the frozen card state per [ISSU-1325](https://linear.app/moov/issue/ISSU-1325/moov-go-update-to-support-frozen-card-state). The GET and PATCH state models are kept separate — per the ticket — since what's used for GET vs PATCH is likely to diverge again.

## Notes

Cut a corresponding [release](https://github.com/moovfinancial/moov-go/releases) after this merges and is tagged (not blocked by service deployments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)