### PR TITLE
docs(agents): require signed messages starting with a robot emoji

### DIFF
--- a/.agents/styleguide.md
+++ b/.agents/styleguide.md
@@ -1,0 +1,75 @@
+# Go Style Guide for moov-go
+
+This document outlines the Go coding style and best practices for this project.
+
+## Agent messages
+
+Every review comment and summary must start with 🤖 and end with a signature that names the agent (for example `— Gemini`). Write in ASD-STE100 Simplified Technical English. Do not omit the emoji or the signature. This also applies to short comments.
+
+## Base Style Guide
+
+Refer to the official Go Code Review Comments and Effective Go for general guidelines.
+
+## Project-Specific Rules
+
+Prioritize these rules above everything else:
+
+*   **Variable Naming:** Use `camelCase` for local variables and `PascalCase` for exported identifiers.
+*   **Error Handling:** Always return errors explicitly and handle them immediately. Avoid ignoring errors.
+*   **Function Length:** Prefer small, single-purpose functions. There's no fixed line limit—size functions by responsibility and readability, and extract helpers when a function becomes hard to follow.
+*   **Package Structure:** Organize code into small, focused packages.
+*   **Public API:** `pkg/moov` and `pkg/mvYYMM` are the published SDK. Do not rename or remove exported identifiers without a breaking-change PR.
+
+## PR Title Format
+
+Every PR must have a structured title. As part of your review, check the PR title and suggest a corrected title if it does not match the required format. A format based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), customized for Moov:
+
+```
+<type>(<component>[,component])[!]: <description>
+```
+
+**Type** (required):
+
+| Type | Meaning |
+|---|---|
+| `feat` | New functionality or capability |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring with no behavior change |
+| `perf` | Performance improvement with no behavior change |
+| `deprecate` | Marking functionality as deprecated for future removal |
+| `docs` | Documentation-only changes |
+| `test` | Adding or updating tests with no production code change |
+| `chore` | Tooling, CI, build, dependencies |
+
+**Component** (required for `feat`, `fix`, `refactor`, `perf`, `deprecate`; optional for `docs`, `test`, `chore`) — the area of the SDK affected. Use names such as `transfers`, `accounts`, `cards`, `wallets`, `webhooks`, `bankaccounts`, `schedules`, `underwriting`, `client`. Multiple components are comma-separated: `(transfers,wallets)`.
+
+**Breaking change indicator** (`!`) — required when the change could break consumers: renaming exported types, changing JSON tags, removing methods, or changing default request behavior. Applies to the PR as a whole; clarify details in the description.
+
+**Description** — imperative mood, lowercase, concise. What the PR does, not how.
+
+**Note** Humans may format the PR title differently, such as `ticket number - description` or `[environment] ticket number - description`. This is valid for PRs created by humans and should not be flagged. Agents should use the Conventional Commit format.
+
+### Examples
+
+| Before | After |
+|---|---|
+| `[LEDG-4056] added patch account` | `feat(accounts): add PatchAccount client method` |
+| `Car 4431: card metadata` | `feat(cards): add GetCardMetadata` |
+| `fix transfer controls` | `fix(transfers): model TransferControls on the API response` |
+| `fix: misc bugs` | `fix(client): handle empty bearer token as basic auth` |
+| `Retemplate` | `chore: update lint workflow` |
+| `nullable transfer fields` | `feat(transfers): support nulling fields via Nullable` |
+| `Remove old update account` | `fix(accounts)!: remove UpdateAccount in favor of PatchAccount` |
+| `refactor: simplify http helper` | `refactor(client): simplify CallHttp header setup` |
+
+Linear ticket references (CAR-*, LEDG-*, FE-*) go in the PR description, not the title.
+
+### What to check
+
+1. If the PR title does not match the format, suggest a corrected title based on the PR's changes.
+2. If the type is wrong (e.g., `feat` used for a bug fix), suggest the correct type.
+3. If the component is missing, infer it from the files changed and suggest it.
+4. If the change is breaking but `!` is missing, flag it and suggest the corrected title.
+5. Linear ticket references (e.g., CAR-4349, LEDG-3920) should not be in the title — they belong in the PR description or in the branch name.
+
+Always present the suggested title in a code block so the author can easily copy and paste it.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+See @AGENTS.md
+
+Start every message with 🤖. Write in ASD-STE100 Simplified Technical English. End with a signature that identifies you (for example `— Claude`).

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -20,6 +20,7 @@ Create a pull request for the current branch.
    - Focus on what the PR does, not how
    - `chore`, `docs`, `test` do not require a component
    - `!` is required for breaking changes
+   - Do not include Linear ticket references (e.g., CAR-*, LEDG-*) in the title
 8. Determine which GitHub labels to apply:
    - `feat` -> `enhancement`
    - `fix` -> `bug`
@@ -52,7 +53,8 @@ Create a pull request for the current branch.
    - End with a signature line naming the agent, e.g. `— Claude`.
 
 10. Before creating the PR, show the user the generated title, labels, and description. Ask for confirmation.
-11. Create the PR using `gh pr create` with the generated title, description, and labels.
+11. Create the PR using `gh pr create --title "TITLE" --body "BODY"` with the generated title, description, and labels.
+    - Use `--title` and `--body` (or `--body-file`) so the command is not interactive.
     - Use `--label` flag for each label (e.g., `--label enhancement`)
     - Push the branch first if needed (`git push -u origin HEAD`)
     - If a label doesn't exist on the repo, retry without that label.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,82 @@
+Create a pull request for the current branch.
+
+## Steps
+
+1. Determine the default branch of the repository by running `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`.
+2. Fetch the latest default branch from the remote: `git fetch origin <default-branch>`.
+3. Run `git log origin/<default-branch>..HEAD --oneline` to see all commits on this branch.
+4. Run `git diff origin/<default-branch>...HEAD --stat` to see which files changed.
+5. Run `git diff origin/<default-branch>...HEAD` to read the actual changes.
+6. Analyze the changes to determine:
+   - **Type**: `feat`, `fix`, `refactor`, `perf`, `deprecate`, `docs`, `test`, or `chore`
+   - **Component**: infer from the area of the codebase that changed. Use a short, lowercase name (e.g. `transfers`, `accounts`, `cards`, `client`). If the change spans the whole project, omit the component.
+   - **Breaking change**: whether this could break existing consumers or dependents. If yes, add `!` after the component.
+7. Generate the PR title in this format:
+   ```
+   <type>(<component>)[!]: <description>
+   ```
+   Rules:
+   - Description must be imperative mood, lowercase, concise
+   - Focus on what the PR does, not how
+   - `chore`, `docs`, `test` do not require a component
+   - `!` is required for breaking changes
+8. Determine which GitHub labels to apply:
+   - `feat` -> `enhancement`
+   - `fix` -> `bug`
+   - `docs` -> `documentation`
+   - `refactor`, `perf`, `deprecate`, `test`, `chore` -> no default GH label (skip `--label` for these)
+   - If the PR has `!` (breaking change), add `breaking-change` label. If the label doesn't exist on the repo, skip it — don't fail.
+9. Generate the PR description using this template:
+
+   ```
+   ## What
+
+   <!-- 1-3 bullet points: what changed -->
+   - ...
+
+   ## Why
+
+   <!-- Brief explanation of motivation or context -->
+
+   ## Notes
+
+   <!-- Optional: anything reviewers should know, migration steps, breaking change details. Delete if not needed. -->
+   ```
+
+   Fill in the template:
+   - Prefix the entire description with 🤖 as the first character.
+   - Write the description in ASD-STE100 Simplified Technical English.
+   - "What" — bulleted list of concrete changes
+   - "Why" — motivation: what problem this solves or what it enables
+   - "Notes" — only include if there are breaking changes, migration steps, or important reviewer context. Delete the section entirely otherwise.
+   - End with a signature line naming the agent, e.g. `— Claude`.
+
+10. Before creating the PR, show the user the generated title, labels, and description. Ask for confirmation.
+11. Create the PR using `gh pr create` with the generated title, description, and labels.
+    - Use `--label` flag for each label (e.g., `--label enhancement`)
+    - Push the branch first if needed (`git push -u origin HEAD`)
+    - If a label doesn't exist on the repo, retry without that label.
+12. Return the PR URL.
+
+## Label mapping
+
+| Type | GitHub Label |
+|---|---|
+| `feat` | `enhancement` |
+| `fix` | `bug` |
+| `docs` | `documentation` |
+| Any type with `!` | also add `breaking-change` (if it exists on the repo) |
+
+## Examples
+
+Good PR titles:
+```
+feat(transfers): add cancellation client methods
+fix(accounts): return 404 instead of 500 for missing resources
+refactor(client): extract bearer-token header setup
+fix(transfers)!: require account-prefixed transfer paths
+docs: update installation snippet
+chore: upgrade Go to 1.26
+test(mhooks): add signature mismatch cases
+deprecate(accounts): mark UpdateAccount for removal
+```

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,1 @@
+../.agents/styleguide.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+See [AGENTS.md](../AGENTS.md).
+
+Start every message with 🤖. Write in ASD-STE100 Simplified Technical English. End with a signature that identifies you (for example `— Copilot`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in the `moov-go` repo. This is the single source of truth for agent instructions; vendor-specific tools point back here.
+
+## Agent messages
+
+Each message that an agent writes must follow these rules. This includes chat replies, PR comments, review comments, and PR descriptions.
+
+1. **Start with 🤖** as the first character.
+2. **Write in [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/)** (Issue 9):
+   - Use short sentences. Use a maximum of 20 words for instructions and 25 words for descriptions.
+   - Write one instruction or one fact in each sentence.
+   - Use the active voice. For instructions, use the imperative.
+   - Do not use contractions. Write `do not`, not `don't`.
+   - Do not omit articles (`a`, `the`) to make a sentence shorter.
+   - Use American English spelling.
+   - Use one word for one meaning. Do not use synonyms for the same thing.
+   - Keep noun clusters to three words or fewer.
+   - Use a vertical list when a sentence has many items or steps.
+   - Domain terms (`Go`, `SDK`, `Moov`, `ACH`, `RTP`) are technical nouns. You can use them.
+3. **Sign the last line** with the product you are running as:
+
+   ```
+   — Claude
+   ```
+
+   Use `Claude`, `Gemini`, `Copilot`, `Codex`, `Cursor`, `Grok`, or the equivalent name. Do not skip the emoji or the signature. This also applies to short replies.
+
+Commit messages are exempt. They follow the Conventional Commits format in the styleguide.
+
+## What this repo is
+
+`moov-go` is the official Go SDK for the [Moov payments API](https://docs.moov.io/api/). It is a library. It does not run a server.
+
+Consumers import `github.com/moovfinancial/moov-go/pkg/moov` and call `moov.NewClient`.
+
+## Layout
+
+- `pkg/moov` — HTTP client, shared request helpers, and default API models.
+- `pkg/mvYYMM` — version-pinned models and wrappers. They send `X-Moov-Version` for that release (for example `pkg/mv2607` uses `moov.Version2026_07`).
+- `pkg/mhooks` — webhook signature checks. These tests do not need live API credentials.
+- `examples/` — integration examples that hit the live Moov API.
+- `internal/testtools` — sandbox account IDs and helpers for integration tests.
+
+## Commands
+
+```bash
+make build                          # go build ./...
+make check                          # download lint-project.sh, then lint and test
+SKIP_TESTS=yes make check           # lint only
+SKIP_LINTERS=yes make check         # tests only
+go test ./pkg/mhooks/... ./pkg/mv2607/...   # unit tests that do not need credentials
+go test ./...                       # full suite, including live API tests
+go test -run TestName ./pkg/moov/...        # one test
+go vet ./...
+```
+
+`make check` downloads `lint-project.sh` from `moov-io/infra`. Cover threshold is 30 percent (`COVER_THRESHOLD=30.0`).
+
+## Credentials
+
+Copy `secrets-template.env` to `secrets.env`. The Makefile loads `secrets.env` when that file exists.
+
+- `MOOV_PUBLIC_KEY` / `MOOV_SECRET_KEY` — required for integration tests and examples
+- `MOOV_HOST` — optional. Default is `api.moov.io`
+- `PLAID_CLIENT_ID` / `PLAID_SECRET` — only for Plaid examples
+
+Most tests in `pkg/moov` and `examples/` call the live API. Without credentials those tests fail. `pkg/mhooks` and httptest cases in `pkg/mv2607` do not need credentials.
+
+## Versioned APIs
+
+Add version-specific types and methods in `pkg/mvYYMM`, not by changing shared `pkg/moov` models in place.
+
+- Put the versioned client wrapper next to the models for that version.
+- Pass the matching `moov.Version` constant so requests set `X-Moov-Version`.
+- Prefer httptest unit tests for versioned packages. Add live tests only when the sandbox must prove the call.
+
+Exported `pkg/moov` changes are a public SDK contract. A renamed field or a removed method is a breaking change. Mark the PR title with `!`.
+
+## Styleguide
+
+See [.agents/styleguide.md](.agents/styleguide.md) for the PR title format (Conventional Commits variant) and Go conventions. Gemini Code Assist only reads `.gemini/styleguide.md`, so that path is a symlink to the single `.agents/styleguide.md` source — edit the `.agents/styleguide.md` file, never a separate copy.


### PR DESCRIPTION
🤖

## What

- Require each agent message to start with 🤖 and end with a product signature.
- Require [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) (Issue 9) for chat replies, PR comments, review comments, and PR descriptions.
- Put the rule in `AGENTS.md`, `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/styleguide.md`, and `.agents/styleguide.md`.

## Why

Readers must see that an agent wrote the text, and which agent wrote it. STE keeps that text short and unambiguous.

## Notes

Commit messages are exempt. They stay on Conventional Commits. Domain terms such as Go, SDK, and Moov are technical nouns.

— Grok