### PR TITLE
feat(issuing): add LastFourCardNumber to IssuedCardTransaction and IssuedCardAuthorization

### DIFF
--- a/pkg/moov/card_issuing_models.go
+++ b/pkg/moov/card_issuing_models.go
@@ -334,15 +334,16 @@ const (
 )
 
 type IssuedCardAuthorization struct {
-	AuthorizationID  string                        `json:"authorizationID"`
-	IssuedCardID     string                        `json:"issuedCardID"`
-	FundingWalletID  string                        `json:"fundingWalletID"`
-	CreatedOn        time.Time                     `json:"createdOn"`
-	Network          IssuedCardTransactionNetwork  `json:"network"`
-	AuthorizedAmount string                        `json:"authorizedAmount"`
-	Status           IssuedCardAuthorizationStatus `json:"status"`
-	MerchantData     IssuedCardTransactionMerchant `json:"merchantData"`
-	CardTransactions []string                      `json:"cardTransactions,omitempty"`
+	AuthorizationID    string                        `json:"authorizationID"`
+	IssuedCardID       string                        `json:"issuedCardID"`
+	LastFourCardNumber *string                       `json:"lastFourCardNumber,omitempty"`
+	FundingWalletID    string                        `json:"fundingWalletID"`
+	CreatedOn          time.Time                     `json:"createdOn"`
+	Network            IssuedCardTransactionNetwork  `json:"network"`
+	AuthorizedAmount   string                        `json:"authorizedAmount"`
+	Status             IssuedCardAuthorizationStatus `json:"status"`
+	MerchantData       IssuedCardTransactionMerchant `json:"merchantData"`
+	CardTransactions   []string                      `json:"cardTransactions,omitempty"`
 }
 
 // IssuedCardTransactionNetwork represents name of the network a card transaction is routed through
@@ -459,14 +460,15 @@ func WithIssuedCardAuthorizationEventCount(count int) ListIssuedCardAuthorizatio
 }
 
 type IssuedCardTransaction struct {
-	CardTransactionID string                        `json:"cardTransactionID"`
-	IssuedCardID      string                        `json:"issuedCardID"`
-	FundingWalletID   string                        `json:"fundingWalletID"`
-	Amount            string                        `json:"amount"`
-	AuthorizationID   *string                       `json:"authorizationID,omitempty"`
-	CreatedOn         time.Time                     `json:"createdOn"`
-	AuthorizedOn      time.Time                     `json:"authorizedOn"`
-	MerchantData      IssuedCardTransactionMerchant `json:"merchantData"`
+	CardTransactionID  string                        `json:"cardTransactionID"`
+	IssuedCardID       string                        `json:"issuedCardID"`
+	LastFourCardNumber *string                       `json:"lastFourCardNumber,omitempty"`
+	FundingWalletID    string                        `json:"fundingWalletID"`
+	Amount             string                        `json:"amount"`
+	AuthorizationID    *string                       `json:"authorizationID,omitempty"`
+	CreatedOn          time.Time                     `json:"createdOn"`
+	AuthorizedOn       time.Time                     `json:"authorizedOn"`
+	MerchantData       IssuedCardTransactionMerchant `json:"merchantData"`
 }
 
 type ListIssuedCardTransactionsFilter callArg

--- a/pkg/moov/card_issuing_test.go
+++ b/pkg/moov/card_issuing_test.go
@@ -231,6 +231,7 @@ func TestIssuedCardAuthorizationMarshal(t *testing.T) {
 	input := []byte(`{
 			"authorizationID": "220c75d3-fac6-4572-9379-a2a2fb29f8cf",
 			"issuedCardID": "ec7e1848-dc80-4ab0-8827-dd7fc0737b43",
+			"lastFourCardNumber": "1234",
 			"fundingWalletID": "50469144-f859-46dc-bdbd-9587c2fa7b42",
 			"createdOn": "2023-11-08T23:06:16Z",
 			"network": "visa",
@@ -260,6 +261,8 @@ func TestIssuedCardAuthorizationMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "220c75d3-fac6-4572-9379-a2a2fb29f8cf", authorization.AuthorizationID)
+	require.NotNil(t, authorization.LastFourCardNumber)
+	require.Equal(t, "1234", *authorization.LastFourCardNumber)
 }
 
 func TestIssuedCardAuthorizationEventMarshal(t *testing.T) {
@@ -286,6 +289,7 @@ func TestIssuedCardTransactionMarshal(t *testing.T) {
 	input := []byte(`{
 			"cardTransactionID": "86d4b88b-eb1b-4640-941c-d8f087256b90",
 			"issuedCardID": "ec7e1848-dc80-4ab0-8827-dd7fc0737b43",
+			"lastFourCardNumber": "1234",
 			"fundingWalletID": "50469144-f859-46dc-bdbd-9587c2fa7b42",
 			"amount": "-1.23",
 			"authorizationID": "220c75d3-fac6-4572-9379-a2a2fb29f8cf",
@@ -311,6 +315,8 @@ func TestIssuedCardTransactionMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "86d4b88b-eb1b-4640-941c-d8f087256b90", transaction.CardTransactionID)
+	require.NotNil(t, transaction.LastFourCardNumber)
+	require.Equal(t, "1234", *transaction.LastFourCardNumber)
 }
 
 func Test_CardIssuing(t *testing.T) {


### PR DESCRIPTION
🤖

## What is new

`IssuedCardTransaction` and `IssuedCardAuthorization` get a new optional field, `LastFourCardNumber`. The field maps to `lastFourCardNumber` in the API response.

The API adds this field next to `issuedCardID` on both models. Callers can show which card was used without a second request for each row.

## Why the field is a pointer

The API omits the field for records written before the service started to store the last four. The Go field is a `*string` with `omitempty`. This matches `AuthorizationID` on the same struct.

## Tests

The decode tests for both models now include `lastFourCardNumber` and assert the value. `go test ./pkg/moov/ -run Marshal` passes.

## Related

- Linear: [ISSU-1068](https://linear.app/moov/issue/ISSU-1068/card-transactions-add-last-4-of-the-card-to-get-responses)
- API spec: moovfinancial/moov-api#982
- Service change: card-transactions PR to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude
