### PR TITLE
test(receipts): wait for transfer projection

### DIFF
--- a/pkg/moov/receipt_test.go
+++ b/pkg/moov/receipt_test.go
@@ -9,70 +9,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Tests that an async transfer becomes queryable before a receipt references it.
 func Test_Receipts(t *testing.T) {
 	mc := NewTestClient(t)
 
 	customer := CreateTemporaryTestAccount(t, mc, createTestIndividualAccount())
 	customerCard := createTemporaryCard(t, mc, customer.AccountID)
 
-	var transfer *moov.TransferStarted = nil
-	var receipt *moov.Receipt = nil
+	var transfer *moov.TransferStarted
+	var receipt *moov.Receipt
 
 	t.Run("make async transfer", func(t *testing.T) {
-		started, err := mc.CreateTransfer(BgCtx(), testtools.PARTNER_ID, moov.CreateTransfer{
-			Source: moov.CreateTransfer_Source{
-				PaymentMethodID: customerCard.PaymentMethods[0].PaymentMethodID,
-			},
-			Destination: moov.CreateTransfer_Destination{
-				PaymentMethodID: testtools.MERCHANT_WALLET_PM_ID,
-			},
-			Amount: moov.Amount{
-				Currency: "usd",
-				Value:    1,
-			},
-		}).Started()
-		NoResponseError(t, err)
-
-		// We made an async transfer, so completed should be nil, while started not nil
-		require.NotNil(t, started)
-
-		transfer = started
-		require.Eventually(t, func() bool {
-			_, err = mc.GetTransfer(BgCtx(), testtools.PARTNER_ID, transfer.TransferID)
-			return err == nil
-		}, 10*time.Second, 100*time.Millisecond)
-		require.NoError(t, err)
+		transfer = createReceiptTestTransfer(t, mc, customerCard.PaymentMethods[0].PaymentMethodID)
 	})
 
 	t.Run("create receipt", func(t *testing.T) {
-		require.NotNil(t, transfer)
-
-		receipts, err := mc.CreateReceipt(BgCtx(), moov.CreateReceipt{
-			Kind:          "sale.customer.v1",
-			ForTransferID: &transfer.TransferID,
-			Email:         moov.PtrOf("noreply@moov.io"),
-		})
-		require.NoError(t, err)
-		require.Len(t, receipts, 1)
-		require.NotEmpty(t, receipts[0].ID)
-
-		receipt = &receipts[0]
-		t.Logf("receipt: %+v\n", receipt)
+		receipt = createTestReceipt(t, mc, transfer.TransferID)
 	})
 
 	t.Run("list receipts", func(t *testing.T) {
-		require.NotNil(t, transfer)
-
-		receipts, err := mc.ListReceipts(BgCtx(), moov.ReceiptByTransferID(transfer.TransferID))
-		require.NoError(t, err)
-		require.Len(t, receipts, 1)
-
-		// The receipt may be sent or not by this point so we need to clear out the sentFor list
-		for i := range receipts {
-			receipts[i].SentFor = nil
-		}
-
-		require.Contains(t, receipts, *receipt)
+		requireTestReceiptListed(t, mc, transfer.TransferID, receipt)
 	})
+}
+
+func createReceiptTestTransfer(t *testing.T, mc *moov.Client, paymentMethodID string) *moov.TransferStarted {
+	t.Helper()
+
+	transfer, err := mc.CreateTransfer(BgCtx(), testtools.PARTNER_ID, moov.CreateTransfer{
+		Source: moov.CreateTransfer_Source{
+			PaymentMethodID: paymentMethodID,
+		},
+		Destination: moov.CreateTransfer_Destination{
+			PaymentMethodID: testtools.MERCHANT_WALLET_PM_ID,
+		},
+		Amount: moov.Amount{
+			Currency: "usd",
+			Value:    1,
+		},
+	}).Started()
+	NoResponseError(t, err)
+	require.NotNil(t, transfer)
+
+	require.Eventually(t, func() bool {
+		_, err := mc.GetTransfer(BgCtx(), testtools.PARTNER_ID, transfer.TransferID)
+		return err == nil
+	}, 3*time.Second, 250*time.Millisecond)
+
+	return transfer
+}
+
+func createTestReceipt(t *testing.T, mc *moov.Client, transferID string) *moov.Receipt {
+	t.Helper()
+
+	receipts, err := mc.CreateReceipt(BgCtx(), moov.CreateReceipt{
+		Kind:          "sale.customer.v1",
+		ForTransferID: &transferID,
+		Email:         moov.PtrOf("noreply@moov.io"),
+	})
+	require.NoError(t, err)
+	require.Len(t, receipts, 1)
+	require.NotEmpty(t, receipts[0].ID)
+
+	t.Logf("receipt: %+v\n", &receipts[0])
+	return &receipts[0]
+}
+
+func requireTestReceiptListed(t *testing.T, mc *moov.Client, transferID string, receipt *moov.Receipt) {
+	t.Helper()
+
+	receipts, err := mc.ListReceipts(BgCtx(), moov.ReceiptByTransferID(transferID))
+	require.NoError(t, err)
+	require.Len(t, receipts, 1)
+
+	for i := range receipts {
+		receipts[i].SentFor = nil
+	}
+
+	require.Contains(t, receipts, *receipt)
 }

--- a/pkg/moov/receipt_test.go
+++ b/pkg/moov/receipt_test.go
@@ -2,12 +2,14 @@ package moov_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/moovfinancial/moov-go/internal/testtools"
 	"github.com/moovfinancial/moov-go/pkg/moov"
 	"github.com/stretchr/testify/require"
 )
 
+// Tests that an async transfer becomes queryable before a receipt references it.
 func Test_Receipts(t *testing.T) {
 	mc := NewTestClient(t)
 
@@ -36,6 +38,11 @@ func Test_Receipts(t *testing.T) {
 		require.NotNil(t, started)
 
 		transfer = started
+		require.Eventually(t, func() bool {
+			_, err = mc.GetTransfer(BgCtx(), testtools.PARTNER_ID, transfer.TransferID)
+			return err == nil
+		}, 10*time.Second, 100*time.Millisecond)
+		require.NoError(t, err)
 	})
 
 	t.Run("create receipt", func(t *testing.T) {

--- a/pkg/moov/receipt_test.go
+++ b/pkg/moov/receipt_test.go
@@ -15,74 +15,59 @@ func Test_Receipts(t *testing.T) {
 	customer := CreateTemporaryTestAccount(t, mc, createTestIndividualAccount())
 	customerCard := createTemporaryCard(t, mc, customer.AccountID)
 
-	var transfer *moov.TransferStarted
-	var receipt *moov.Receipt
+	var transfer *moov.TransferStarted = nil
+	var receipt *moov.Receipt = nil
 
 	t.Run("make async transfer", func(t *testing.T) {
-		transfer = createReceiptTestTransfer(t, mc, customerCard.PaymentMethods[0].PaymentMethodID)
+		started, err := mc.CreateTransfer(BgCtx(), testtools.PARTNER_ID, moov.CreateTransfer{
+			Source: moov.CreateTransfer_Source{
+				PaymentMethodID: customerCard.PaymentMethods[0].PaymentMethodID,
+			},
+			Destination: moov.CreateTransfer_Destination{
+				PaymentMethodID: testtools.MERCHANT_WALLET_PM_ID,
+			},
+			Amount: moov.Amount{
+				Currency: "usd",
+				Value:    1,
+			},
+		}).Started()
+		NoResponseError(t, err)
+		require.NotNil(t, started)
+
+		transfer = started
+		require.Eventually(t, func() bool {
+			_, err := mc.GetTransfer(BgCtx(), testtools.PARTNER_ID, transfer.TransferID)
+			return err == nil
+		}, 3*time.Second, 250*time.Millisecond)
 	})
 
 	t.Run("create receipt", func(t *testing.T) {
-		receipt = createTestReceipt(t, mc, transfer.TransferID)
+		require.NotNil(t, transfer)
+
+		receipts, err := mc.CreateReceipt(BgCtx(), moov.CreateReceipt{
+			Kind:          "sale.customer.v1",
+			ForTransferID: &transfer.TransferID,
+			Email:         moov.PtrOf("noreply@moov.io"),
+		})
+		require.NoError(t, err)
+		require.Len(t, receipts, 1)
+		require.NotEmpty(t, receipts[0].ID)
+
+		receipt = &receipts[0]
+		t.Logf("receipt: %+v\n", receipt)
 	})
 
 	t.Run("list receipts", func(t *testing.T) {
-		requireTestReceiptListed(t, mc, transfer.TransferID, receipt)
+		require.NotNil(t, transfer)
+
+		receipts, err := mc.ListReceipts(BgCtx(), moov.ReceiptByTransferID(transfer.TransferID))
+		require.NoError(t, err)
+		require.Len(t, receipts, 1)
+
+		for i := range receipts {
+			receipts[i].SentFor = nil
+		}
+
+		require.Contains(t, receipts, *receipt)
 	})
-}
-
-func createReceiptTestTransfer(t *testing.T, mc *moov.Client, paymentMethodID string) *moov.TransferStarted {
-	t.Helper()
-
-	transfer, err := mc.CreateTransfer(BgCtx(), testtools.PARTNER_ID, moov.CreateTransfer{
-		Source: moov.CreateTransfer_Source{
-			PaymentMethodID: paymentMethodID,
-		},
-		Destination: moov.CreateTransfer_Destination{
-			PaymentMethodID: testtools.MERCHANT_WALLET_PM_ID,
-		},
-		Amount: moov.Amount{
-			Currency: "usd",
-			Value:    1,
-		},
-	}).Started()
-	NoResponseError(t, err)
-	require.NotNil(t, transfer)
-
-	require.Eventually(t, func() bool {
-		_, err := mc.GetTransfer(BgCtx(), testtools.PARTNER_ID, transfer.TransferID)
-		return err == nil
-	}, 3*time.Second, 250*time.Millisecond)
-
-	return transfer
-}
-
-func createTestReceipt(t *testing.T, mc *moov.Client, transferID string) *moov.Receipt {
-	t.Helper()
-
-	receipts, err := mc.CreateReceipt(BgCtx(), moov.CreateReceipt{
-		Kind:          "sale.customer.v1",
-		ForTransferID: &transferID,
-		Email:         moov.PtrOf("noreply@moov.io"),
-	})
-	require.NoError(t, err)
-	require.Len(t, receipts, 1)
-	require.NotEmpty(t, receipts[0].ID)
-
-	t.Logf("receipt: %+v\n", &receipts[0])
-	return &receipts[0]
-}
-
-func requireTestReceiptListed(t *testing.T, mc *moov.Client, transferID string, receipt *moov.Receipt) {
-	t.Helper()
-
-	receipts, err := mc.ListReceipts(BgCtx(), moov.ReceiptByTransferID(transferID))
-	require.NoError(t, err)
-	require.Len(t, receipts, 1)
-
-	for i := range receipts {
-		receipts[i].SentFor = nil
-	}
-
-	require.Contains(t, receipts, *receipt)
 }


### PR DESCRIPTION
## Why
The receipt integration test can create a receipt before transfersbff2 projects its asynchronous transfer.

This race caused the [CI failure](https://github.com/moovfinancial/moov-go/actions/runs/33890516667/job/101080758229#step:6:60). A [Honeycomb query](https://ui.honeycomb.io/moov/environments/production/datasets/receipts/result/jNiCEL2M2zK) confirmed the projection delay.

## What changed
- Wait for `GetTransfer` to find the asynchronous transfer before creating the receipt.
- Limit the wait to 3 seconds with 250-millisecond polling.
