### PR TITLE
test(connections): extend projection polling window

### DIFF
--- a/pkg/moov/connections_test.go
+++ b/pkg/moov/connections_test.go
@@ -35,7 +35,7 @@ func Test_ShareConnection(t *testing.T) {
 		require.Eventually(t, func() bool {
 			connections, err = mv2507.Accounts.ListConnected(BgCtx(), *mc, merchant.AccountID)
 			return err == nil && len(connections) > 0
-		}, time.Second*1, time.Millisecond*100)
+		}, 3*time.Second, 250*time.Millisecond)
 
 		require.NoError(t, err)
 		require.NotNil(t, connections)


### PR DESCRIPTION
🤖 ## Why

`Test_ShareConnection` waits for an eventually consistent Accounts projection.

The one-second deadline is too short when requests reach replicas with different projection states. The same test passed on rerun without a code change.

## Evidence

- [Ubuntu failure](https://github.com/moovfinancial/moov-go/actions/runs/33925027788)
- [Ubuntu trace](https://ui.honeycomb.io/moov/environments/production/datasets/accounts/result/pxaEWrVfNwf): four empty responses occurred before one non-empty response.
- [Earlier macOS trace](https://ui.honeycomb.io/moov/environments/production/datasets/accounts/result/yhUUV21PP9C): eight empty responses occurred before one non-empty response.

These traces confirm projection delay and replica variation. They do not show when the GitHub runner received the successful response.

## Change

Increase the maximum wait from one second to three seconds. Poll every 250 milliseconds.

— Amp